### PR TITLE
Keep complex logics in jelly as less as possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin
 *.iws
 work
 nbactions.xml
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.3.3</version>
+		</dependency>
+		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>credentials</artifactId>
 			<version>1.9.4</version>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
@@ -3,31 +3,15 @@
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 	<f:entry title="${it.name}" description="${it.description}">
 	    <div name="parameter" description="${it.description}">
-             <j:if test="${it.errorMessage eq 'noWorkspace'}">
+            <j:if test="${it.errorMessage eq 'noWorkspace'}">
                 <p style="color: red;">${%noWorkspaceError}</p>
-             </j:if>
-            <j:choose>
-            	<j:when test="${it.type eq 'PT_TAG'}">
-            	    <input type="hidden" name="name" value="${it.name}" />
-                    <select name="value" size="5" width="200px">
-            		<j:forEach var="val" items="${it.tagMap}" >
-                            <j:choose>
-                                <option value="${val.key}">${val.value}</option>
-                            </j:choose>
-                        </j:forEach>  
-                    </select>
-            	</j:when>
-            	<j:when test="${it.type eq 'PT_REVISION'}">
-            	    <input type="hidden" name="name" value="${it.name}" />
-                    <select name="value" size="5" width="200px">
-            		<j:forEach var="val" items="${it.revisionMap}" >
-                            <j:choose>
-                                <option value="${val.key}">${val.value}</option>
-                            </j:choose>
-                        </j:forEach>  
-                    </select>
-            	</j:when>
-            </j:choose>	
+            </j:if>
+            <st:adjunct includes="lib.form.select.select"/>
+            <input type="hidden" name="name" value="${it.name}" />
+            <select name="value" class="select" size="5" width="200px"
+                    fillUrl="${h.getCurrentDescriptorByNameUrl()}/${it.descriptor.descriptorUrl}/fillValueItems?param=${it.name}">
+                <option value="">${%Retrieving Git references…}</option>
+            </select>
         </div>
 		<div>You must have built the project at least once, to get entries in the list above.</div>
 		<div>If you wipe out your workspace, the plugin needs to clone the repository before it can list the tags/revisions. This may take some time if you have a slow connection or the repository is big.</div>

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
@@ -5,15 +5,25 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
 import static org.mockito.Mockito.mock;
+
+import hudson.model.FreeStyleProject;
 import hudson.model.ParameterValue;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import hudson.model.FreeStyleBuild;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import hudson.tasks.Shell;
+import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition.SortMode;
 
@@ -30,6 +40,8 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author lukanus
  */
 public class GitParameterDefinitionTest extends HudsonTestCase  {
+    private final String repositoryUrl = "https://github.com/jenkinsci/git-parameter-plugin.git";
+    private FreeStyleProject project;
     
     public GitParameterDefinitionTest() {
     }
@@ -297,32 +309,113 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         
     }
 
-    /**
-     * Test of getRevisionMap method, of class GitParameterDefinition.
-     */
+    // Test Descriptor.getProjectSCM()
     @Test
-    public void testGetRevisionMap() {
-   //     System.out.println("getRevisionMap");
-   //     GitParameterDefinition instance = null;
-   //     Map expResult = null;
-   //     Map result = instance.getRevisionMap();
-   //     assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        
+    public void testGetProjectSCM() throws Exception {
+        super.setUp();
+        FreeStyleProject testJob = jenkins.createProject(FreeStyleProject.class, "testGetProjectSCM");
+        GitSCM git = new GitSCM(repositoryUrl);
+        GitParameterDefinition def = new GitParameterDefinition("testName",
+                "PT_REVISION",
+                "testDefaultValue",
+                "testDescription",
+                "testBranch",
+                "*",
+                SortMode.NONE);
+        testJob.addProperty(new ParametersDefinitionProperty(def));
+        assertTrue(def.getDescriptor().getProjectSCM(testJob) == null);
+
+        testJob.setScm(git);
+        assertTrue(git.equals(def.getDescriptor().getProjectSCM(testJob)));
+        super.tearDown();
     }
 
-    /**
-     * Test of getTagMap method, of class GitParameterDefinition.
-     */
+    // Test Descriptor.doFillValueItems() with no SCM configured
     @Test
-    public void testGetTagMap() {
-        System.out.println("Test of getTagMap method");
-   /*      GitParameterDefinition instance = new GitParameterDefinition("name","PT_TAG","defaultValue","description","branch");
-       
-        Map<String,String> result = instance.getTagMap();
-        //assertEquals(expResult, result);
-        if(!result.isEmpty()) {
-            fail();
-        }*/
+    public void testDoFillValueItems_withoutSCM() throws Exception {
+        super.setUp();
+        FreeStyleProject project = jenkins.createProject(FreeStyleProject.class, "testListTags");
+        GitParameterDefinition def = new GitParameterDefinition("testName",
+                "PT_TAG",
+                "testDefaultValue",
+                "testDescription",
+                "testBranch",
+                "*",
+                SortMode.NONE);
+        project.addProperty(new ParametersDefinitionProperty(def));
+
+        ListBoxModel items = def.getDescriptor().doFillValueItems(project, def.getName());
+        assertTrue(isListBoxItem(items, "No Git repository configured in SCM configuration"));
+
+        super.tearDown();
+    }
+
+    // Test Descriptor.doFillValueItems() with listing tags
+    @Test
+    public void testDoFillValueItems_listTags() throws Exception {
+        super.setUp();
+        project = jenkins.createProject(FreeStyleProject.class, "testListTags");
+        project.getBuildersList().add(new Shell("echo test"));
+        setupGit();
+
+        GitParameterDefinition def = new GitParameterDefinition("testName",
+                "PT_TAG",
+                "testDefaultValue",
+                "testDescription",
+                "testBranch",
+                "*",
+                SortMode.NONE);
+        project.addProperty(new ParametersDefinitionProperty(def));
+
+        // Run the build once to get the workspace
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        ListBoxModel items = def.getDescriptor().doFillValueItems(project, def.getName());
+        assertTrue(isListBoxItem(items, "git-parameter-0.2"));
+
+        super.tearDown();
+    }
+
+    // Test Descriptor.doFillValueItems() with listing revisions
+    @Test
+    public void testDoFillValueItems_listRevisions() throws Exception {
+        super.setUp();
+        project = jenkins.createProject(FreeStyleProject.class, "testListRevisions");
+        project.getBuildersList().add(new Shell("echo test"));
+        setupGit();
+
+        GitParameterDefinition def = new GitParameterDefinition("testName",
+                "PT_REVISION",
+                "testDefaultValue",
+                "testDescription",
+                null,
+                "*",
+                SortMode.NONE);
+
+        project.addProperty(new ParametersDefinitionProperty(def));
+
+        // Run the build once to get the workspace
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        ListBoxModel items = def.getDescriptor().doFillValueItems(project, def.getName());
+        assertTrue(isListBoxItem(items, "00a8385c"));
+
+        super.tearDown();
+    }
+
+    private boolean isListBoxItem(ListBoxModel items, String item) {
+        boolean itemExists = false;
+        for (int i=0; i<items.size(); i++) {
+            if (items.get(i).value.contains(item)) {
+                itemExists = true;
+            }
+        }
+        return itemExists;
+    }
+
+    private void setupGit() throws IOException {
+        UserRemoteConfig config = new UserRemoteConfig(repositoryUrl, null, null, null);
+        List<UserRemoteConfig> configs = new ArrayList<UserRemoteConfig>();
+        configs.add(config);
+        GitSCM git = new GitSCM(configs, null, false, null, null, null, null);
+        project.setScm(git);
     }
 }


### PR DESCRIPTION
Move logics out of index.jelly while using doFillFIELDItems to
fill the value of Git parameters.

It improves the testability of code.
