### PR TITLE
Performance improvements when listing remote tags and branches

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -45,7 +45,6 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
-import org.jfree.util.Log;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -10,7 +10,6 @@ import hudson.model.AbstractProject;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Run;
-import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.GitSCM;
@@ -24,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +34,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import jenkins.model.Jenkins;
+
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -58,6 +57,7 @@ public class GitParameterDefinition extends ParameterDefinition implements
 	public static final String PARAMETER_TYPE_REVISION = "PT_REVISION";
 	public static final String PARAMETER_TYPE_BRANCH = "PT_BRANCH";
 	public static final String PARAMETER_TYPE_TAG_BRANCH = "PT_BRANCH_TAG";
+	public static final String REMOTE_ORIGIN = "origin";
 
 	private final UUID uuid;
 	private static final Logger LOGGER = Logger
@@ -65,8 +65,7 @@ public class GitParameterDefinition extends ParameterDefinition implements
 
 	private String type;
 	private String branch;
-	private String tagFilter;
-	private String branchfilter;
+	private String filter;
 	
 	private SortMode sortMode;
 
@@ -76,7 +75,7 @@ public class GitParameterDefinition extends ParameterDefinition implements
 	@DataBoundConstructor
 	public GitParameterDefinition(String name, String type,
 			String defaultValue, String description, String branch,
-			String branchfilter, String tagFilter, SortMode sortMode) {
+			String filter, SortMode sortMode) {
 		super(name, description);
 		this.type = type;
 		this.defaultValue = defaultValue;
@@ -84,13 +83,7 @@ public class GitParameterDefinition extends ParameterDefinition implements
 		this.uuid = UUID.randomUUID();
 		this.sortMode = sortMode;
 		
-		if (isNullOrWhitespace(tagFilter)) {
-			this.tagFilter = "*";
-		} else {
-			this.tagFilter = tagFilter;
-		}
-		
-		setBranchfilter(branchfilter);
+		setFilter(filter);
 	}
 
 	@Override
@@ -168,12 +161,16 @@ public class GitParameterDefinition extends ParameterDefinition implements
 		this.sortMode = sortMode;
 	}
 
-	public String getTagFilter() {
-		return this.tagFilter;
+	public String getFilter() {
+		return this.filter;
 	}
 
-	public void setTagFilter(String tagFilter) {
-		this.tagFilter = tagFilter;
+	public void setFilter(String filter) {
+		filter = validateFilter(filter);
+		if (isNullOrWhitespace(filter)) {
+			filter = "*";			
+		}
+		this.filter = filter;
 	}
 
 	public String getDefaultValue() {
@@ -182,25 +179,6 @@ public class GitParameterDefinition extends ParameterDefinition implements
 
 	public void setDefaultValue(String defaultValue) {
 		this.defaultValue = defaultValue;
-	}
-	
-	public String getBranchfilter() {
-		return branchfilter;
-	}
-
-	public void setBranchfilter(String branchfilter) {
-		if (isNullOrWhitespace(branchfilter)) {
-			branchfilter = "*";			
-		}
-		// Accept "*" as a wilcard
-		if (!"*".equals(branchfilter)) {
-			try {
-				Pattern.compile(branchfilter);
-			} catch (PatternSyntaxException e) {
-				LOGGER.log(Level.FINE, "Specified branchfilter is not a valid regex. Setting to '*'", e);
-			}
-		}
-		this.branchfilter = branchfilter;
 	}
 	
 	public AbstractProject<?, ?> getParentProject() {
@@ -310,7 +288,7 @@ public class GitParameterDefinition extends ParameterDefinition implements
 							return Collections.singletonMap(errMsg, errMsg);
 						}
 						newgit.init();
-						newgit.clone(remoteURL.toASCIIString(), "origin",
+						newgit.clone(remoteURL.toASCIIString(), REMOTE_ORIGIN,
 								false, null);
 						LOGGER.log(Level.INFO, "generateContents clone done");
 					}
@@ -322,12 +300,12 @@ public class GitParameterDefinition extends ParameterDefinition implements
 					return Collections.singletonMap(errMsg, errMsg);
 				}
 
-				long time = -System.currentTimeMillis();
-				FetchCommand fetch = newgit.fetch_().from(remoteURL,
-						repository.getFetchRefSpecs());
-				fetch.execute();
-				LOGGER.finest("Took " + (time + System.currentTimeMillis()) + "ms to fetch");
 				if (type.equalsIgnoreCase(PARAMETER_TYPE_REVISION)) {
+					// If we use the GitClient#getRemoteReferences function, we don't
+					// need to do a fetch to get tags or branches.
+					FetchCommand fetch = newgit.fetch_().from(remoteURL,
+							repository.getFetchRefSpecs());
+					fetch.execute();
 					List<ObjectId> oid;
 
 					if (this.branch != null && !this.branch.isEmpty()) {
@@ -343,52 +321,36 @@ public class GitParameterDefinition extends ParameterDefinition implements
 					}
 				}
 				if (type.equalsIgnoreCase(PARAMETER_TYPE_TAG)
+						|| type.equalsIgnoreCase(PARAMETER_TYPE_BRANCH)
 						|| type.equalsIgnoreCase(PARAMETER_TYPE_TAG_BRANCH)) {
-
-					Set<String> tagSet = newgit.getTagNames(tagFilter);
-					ArrayList<String> orderedTagNames;
-
+					// We can't rely on the filter paramter, so it's null. 
+					// Different implementations support different filters. At least one only glob, at least one both.
+					// We'll filter things out ourselves below.
+					final Set<String> refSet = 
+							newgit.getRemoteReferences(
+									newgit.getRemoteUrl(REMOTE_ORIGIN), 
+									null, 
+									type.equalsIgnoreCase(PARAMETER_TYPE_BRANCH) || type.equalsIgnoreCase(PARAMETER_TYPE_TAG_BRANCH), 
+									type.equalsIgnoreCase(PARAMETER_TYPE_TAG) || type.equalsIgnoreCase(PARAMETER_TYPE_TAG_BRANCH)).keySet();
+					
+					final ArrayList<String> orderedRefNames;
 					if (this.getSortMode().getIsSorting()) {
-						orderedTagNames = sortByName(tagSet);
+						orderedRefNames = sortByName(refSet);
 						if (this.getSortMode().getIsDescending())
-							Collections.reverse(orderedTagNames);
+							Collections.reverse(orderedRefNames);
 					} else {
-						orderedTagNames = new ArrayList<String>(tagSet);
+						orderedRefNames = new ArrayList<String>(refSet);
 					}
 
-					for (String tagName : orderedTagNames) {
-						paramList.put(tagName, tagName);
-					}
-				}
-				if (type.equalsIgnoreCase(PARAMETER_TYPE_BRANCH)
-						|| type.equalsIgnoreCase(PARAMETER_TYPE_TAG_BRANCH)) {
-					time = -System.currentTimeMillis();
-					Set<String> branchSet = new HashSet<String>();
-					final boolean wildcard = "*".equals(branchfilter);
-					for (Branch branch : newgit.getRemoteBranches()) {
-						// It'd be nice if we could filter on remote branches via the GitClient,
-						// but that's not an option.
-						final String branchName = branch.getName();
-						if (wildcard || branchName.matches(branchfilter)) {
-							branchSet.add(branchName);
+					boolean isWildcard = filter == null || "*".equals(filter);
+					for (String refName : orderedRefNames) {
+						if (isWildcard || refName.matches(filter)) {
+							if (refName.startsWith("refs/heads/")) {
+								refName = refName.substring("refs/heads/".length());
+							}
+							paramList.put(refName, refName);
 						}
 					}
-					LOGGER.finest("Took " + (time + System.currentTimeMillis()) + "ms to fetch branches");
-					
-					time = -System.currentTimeMillis();
-					List<String> orderedBranchNames;
-					if (this.getSortMode().getIsSorting()) {
-						orderedBranchNames = sortByName(branchSet);
-						if (this.getSortMode().getIsDescending())
-							Collections.reverse(orderedBranchNames);
-					} else {
-						orderedBranchNames = new ArrayList<String>(branchSet);
-					}
-
-					for (String branchName : orderedBranchNames) {
-						paramList.put(branchName, branchName);
-					}
-					LOGGER.finest("Took " + (time + System.currentTimeMillis()) + "ms to sort and add to param list.");
 				}
 			}
 			break;
@@ -579,15 +541,65 @@ public class GitParameterDefinition extends ParameterDefinition implements
 			return null;
 		}
 		
-		public FormValidation doCheckBranchfilter(@QueryParameter String value) {
-			if (!"*".equals(value)) {
-				try {
-					Pattern.compile(value); // Validate we've got a valid regex.
-				} catch (PatternSyntaxException e) {
-					return FormValidation.error("The pattern '" + value + "' does not appear to be valid: " + e.getMessage());
-				}
-			}
-			return FormValidation.ok();
+		public FormValidation doCheckFilter(@QueryParameter String value) {
+			return validateFilter(value) != null ? FormValidation.ok() : FormValidation.error("The pattern '" + value + "' is not valid.");
 		}
 	}	
+	
+	/**
+	 * Take a glob or regex filter string and return a regex, if valid.
+	 * @param value the filter to test
+	 * @return A valid regex, or null if invalid.
+	 */
+	private static String validateFilter(String value) {
+		if (isNullOrWhitespace(value)) {
+			return null;
+		}
+		try {
+			Pattern.compile(value); // Validate we've got a valid regex.
+		} catch (PatternSyntaxException e) {
+			try {
+				value = createRefRegexFromGlob(value);
+				Pattern.compile(value);
+			} catch (PatternSyntaxException e2) {
+				return null;
+			}
+		}
+		return value;
+	}
+	
+	/* Taken wholesale from org.jenkinsci.plugins.gitclient.JGitAPIImpl. Might make sense to have this in some common component? */
+	/* Adapted from http://stackoverflow.com/questions/1247772/is-there-an-equivalent-of-java-util-regex-for-glob-type-patterns */
+    private static String createRefRegexFromGlob(String glob)
+    {
+        StringBuilder out = new StringBuilder();
+        if(glob.startsWith("refs/")) {
+            out.append("^");
+        } else {
+            out.append("^.*/");
+        }
+
+        for (int i = 0; i < glob.length(); ++i) {
+            final char c = glob.charAt(i);
+            switch(c) {
+            case '*':
+                out.append(".*");
+                break;
+            case '?':
+                out.append('.');
+                break;
+            case '.':
+                out.append("\\.");
+                break;
+            case '\\':
+                out.append("\\\\");
+                break;
+            default:
+                out.append(c);
+                break;
+            }
+        }
+        out.append('$');
+        return out.toString();
+    }
 }

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -46,11 +46,7 @@
     <f:textbox />
   </f:entry>
   
-  <f:entry title="Branch filter" field="branchfilter">
-    <f:textbox />
-  </f:entry>
-  
-  <f:entry title="Tag filter" field="tagFilter">
+  <f:entry title="Filter" field="filter">
     <f:textbox />
   </f:entry>
   

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -46,6 +46,10 @@
     <f:textbox />
   </f:entry>
   
+  <f:entry title="Branch filter" field="branchfilter">
+    <f:textbox />
+  </f:entry>
+  
   <f:entry title="Tag filter" field="tagFilter">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-branch.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-branch.html
@@ -1,3 +1,3 @@
 <div>
-    Name of branch to look in: 
+    Name of branch to look in. Used only if listing revisions.
 </div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-branchfilter.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-branchfilter.html
@@ -1,3 +1,0 @@
-<div>
-    Regex used to filter displayed branches.
-</div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-branchfilter.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-branchfilter.html
@@ -1,0 +1,3 @@
+<div>
+    Regex used to filter displayed branches.
+</div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-filter.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-filter.html
@@ -1,0 +1,3 @@
+<div>
+    Regex used to filter displayed branches and tags.
+</div>

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
@@ -75,7 +75,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testCreateValue_StaplerRequest() {
         System.out.println("createValue");
               
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*","*",GitParameterDefinition.SortMode.NONE);
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
         
         StaplerRequest request = mock(StaplerRequest.class);
         ParameterValue result = instance.createValue(request);
@@ -85,30 +85,26 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
 
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenNull() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,null,GitParameterDefinition.SortMode.NONE);
-    	assertEquals("*", instance.getTagFilter());
-    	assertEquals("*", instance.getBranchfilter());
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.NONE);
+    	assertEquals("*", instance.getFilter());
     }
     
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ","  ",GitParameterDefinition.SortMode.NONE);
-    	assertEquals("*", instance.getTagFilter());
-    	assertEquals("*", instance.getBranchfilter());
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ",GitParameterDefinition.SortMode.NONE);
+    	assertEquals("*", instance.getFilter());
     }
     
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenEmpty() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","","",GitParameterDefinition.SortMode.NONE);
-    	assertEquals("*", instance.getTagFilter());
-    	assertEquals("*", instance.getBranchfilter());
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","",GitParameterDefinition.SortMode.NONE);
+    	assertEquals("*", instance.getFilter());
     }
     
     @Test
     public void testConstructorInitializesTagToGivenValueWhenNotNullOrWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar","foobar",GitParameterDefinition.SortMode.NONE);
-    	assertEquals("foobar", instance.getTagFilter());
-    	assertEquals("foobar", instance.getBranchfilter());
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar",GitParameterDefinition.SortMode.NONE);
+    	assertEquals("foobar", instance.getFilter());
     }
    
     
@@ -131,7 +127,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     
     @Test
     public void testSortTagsYieldsCorrectOrderWithSmartSortEnabled() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,null,GitParameterDefinition.SortMode.ASCENDING_SMART);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.ASCENDING_SMART);
     	Set<String> tags = new HashSet<String>();
     	tags.add("v_1.0.0.2");
     	tags.add("v_1.0.0.5");
@@ -150,7 +146,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     
     @Test
     public void testSortTagsYieldsCorrectOrderWithSmartSortDisabled() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,null,GitParameterDefinition.SortMode.ASCENDING);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.ASCENDING);
     	Set<String> tags = new HashSet<String>();
     	tags.add("v_1.0.0.2");
     	tags.add("v_1.0.0.5");
@@ -209,7 +205,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         JSONObject jO = JSONObject.fromObject(jsonR);
         
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*","*",GitParameterDefinition.SortMode.NONE);
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
        
         ParameterValue result = instance.createValue(request,jO);
         
@@ -235,7 +231,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testGetType() {
         System.out.println("Test of getType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*","*",GitParameterDefinition.SortMode.NONE);
+        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
         String result = instance.getType();
         assertEquals(expResult, result);
         
@@ -253,7 +249,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testSetType() {
         System.out.println("Test of setType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*","*",GitParameterDefinition.SortMode.NONE);
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
         
         instance.setType(expResult);        
         String result = instance.getType();        
@@ -268,7 +264,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*","*",GitParameterDefinition.SortMode.NONE);       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*",GitParameterDefinition.SortMode.NONE);       
         String result = instance.getDefaultValue();
         assertEquals(expResult, result);
     }
@@ -281,7 +277,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*","*",GitParameterDefinition.SortMode.NONE);       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*",GitParameterDefinition.SortMode.NONE);       
         instance.setDefaultValue(expResult);
         
         String result = instance.getDefaultValue();
@@ -329,7 +325,6 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDescription",
                 "testBranch",
                 "*",
-                "*",
                 SortMode.NONE);
         testJob.addProperty(new ParametersDefinitionProperty(def));
         assertTrue(def.getDescriptor().getProjectSCM(testJob) == null);
@@ -349,7 +344,6 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDefaultValue",
                 "testDescription",
                 "testBranch",
-                "*",
                 "*",
                 SortMode.NONE);
         project.addProperty(new ParametersDefinitionProperty(def));
@@ -373,7 +367,6 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDefaultValue",
                 "testDescription",
                 "testBranch",
-                "*",
                 "*",
                 SortMode.NONE);
         project.addProperty(new ParametersDefinitionProperty(def));
@@ -400,7 +393,6 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDescription",
                 "testBranch",
                 "*",
-                "*",
                 SortMode.NONE);
         project.addProperty(new ParametersDefinitionProperty(def));
 
@@ -425,7 +417,6 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDefaultValue",
                 "testDescription",
                 "testBranch",
-                "*",
                 "*",
                 SortMode.NONE);
         project.addProperty(new ParametersDefinitionProperty(def));
@@ -453,7 +444,6 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDescription",
                 null,
                 "*",
-                "*",
                 SortMode.NONE);
 
         project.addProperty(new ParametersDefinitionProperty(def));
@@ -478,7 +468,6 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "description",
                 "branch",
                 "*",
-                "*",
                 SortMode.NONE);
         job1.addProperty(new ParametersDefinitionProperty(gitParameterDefinition));
         assertEquals("folder/job1", gitParameterDefinition.getParentProject().getFullName());
@@ -488,9 +477,9 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     @Test
     public void testBranchFilterValidation() {
     	final DescriptorImpl descriptor = new DescriptorImpl();
-    	final FormValidation okPsuedoWildcard = descriptor.doCheckBranchfilter("*");
-    	final FormValidation okWildcard = descriptor.doCheckBranchfilter("*");
-    	final FormValidation badWildcard = descriptor.doCheckBranchfilter(".**");
+    	final FormValidation okPsuedoWildcard = descriptor.doCheckFilter("*");
+    	final FormValidation okWildcard = descriptor.doCheckFilter(".*");
+    	final FormValidation badWildcard = descriptor.doCheckFilter("(.*");
     	
     	assertTrue(okPsuedoWildcard.kind == Kind.OK);
     	assertTrue(okWildcard.kind == Kind.OK);

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
@@ -72,7 +72,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testCreateValue_StaplerRequest() {
         System.out.println("createValue");
               
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch", "*",GitParameterDefinition.SortMode.NONE);
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*","*",GitParameterDefinition.SortMode.NONE);
         
         StaplerRequest request = mock(StaplerRequest.class);
         ParameterValue result = instance.createValue(request);
@@ -82,26 +82,30 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
 
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenNull() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.NONE);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,null,GitParameterDefinition.SortMode.NONE);
     	assertEquals("*", instance.getTagFilter());
+    	assertEquals("*", instance.getBranchfilter());
     }
     
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ",GitParameterDefinition.SortMode.NONE);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ","  ",GitParameterDefinition.SortMode.NONE);
     	assertEquals("*", instance.getTagFilter());
+    	assertEquals("*", instance.getBranchfilter());
     }
     
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenEmpty() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","",GitParameterDefinition.SortMode.NONE);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","","",GitParameterDefinition.SortMode.NONE);
     	assertEquals("*", instance.getTagFilter());
+    	assertEquals("*", instance.getBranchfilter());
     }
     
     @Test
     public void testConstructorInitializesTagToGivenValueWhenNotNullOrWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar",GitParameterDefinition.SortMode.NONE);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar","foobar",GitParameterDefinition.SortMode.NONE);
     	assertEquals("foobar", instance.getTagFilter());
+    	assertEquals("foobar", instance.getBranchfilter());
     }
    
     
@@ -124,7 +128,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     
     @Test
     public void testSortTagsYieldsCorrectOrderWithSmartSortEnabled() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.ASCENDING_SMART);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,null,GitParameterDefinition.SortMode.ASCENDING_SMART);
     	Set<String> tags = new HashSet<String>();
     	tags.add("v_1.0.0.2");
     	tags.add("v_1.0.0.5");
@@ -143,7 +147,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     
     @Test
     public void testSortTagsYieldsCorrectOrderWithSmartSortDisabled() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.ASCENDING);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,null,GitParameterDefinition.SortMode.ASCENDING);
     	Set<String> tags = new HashSet<String>();
     	tags.add("v_1.0.0.2");
     	tags.add("v_1.0.0.5");
@@ -202,7 +206,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         JSONObject jO = JSONObject.fromObject(jsonR);
         
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*","*",GitParameterDefinition.SortMode.NONE);
        
         ParameterValue result = instance.createValue(request,jO);
         
@@ -228,7 +232,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testGetType() {
         System.out.println("Test of getType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
+        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*","*",GitParameterDefinition.SortMode.NONE);
         String result = instance.getType();
         assertEquals(expResult, result);
         
@@ -246,7 +250,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testSetType() {
         System.out.println("Test of setType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*","*",GitParameterDefinition.SortMode.NONE);
         
         instance.setType(expResult);        
         String result = instance.getType();        
@@ -261,7 +265,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*",GitParameterDefinition.SortMode.NONE);       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*","*",GitParameterDefinition.SortMode.NONE);       
         String result = instance.getDefaultValue();
         assertEquals(expResult, result);
     }
@@ -274,7 +278,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*",GitParameterDefinition.SortMode.NONE);       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*","*",GitParameterDefinition.SortMode.NONE);       
         instance.setDefaultValue(expResult);
         
         String result = instance.getDefaultValue();
@@ -322,6 +326,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDescription",
                 "testBranch",
                 "*",
+                "*",
                 SortMode.NONE);
         testJob.addProperty(new ParametersDefinitionProperty(def));
         assertTrue(def.getDescriptor().getProjectSCM(testJob) == null);
@@ -341,6 +346,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDefaultValue",
                 "testDescription",
                 "testBranch",
+                "*",
                 "*",
                 SortMode.NONE);
         project.addProperty(new ParametersDefinitionProperty(def));
@@ -364,6 +370,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDefaultValue",
                 "testDescription",
                 "testBranch",
+                "*",
                 "*",
                 SortMode.NONE);
         project.addProperty(new ParametersDefinitionProperty(def));
@@ -390,6 +397,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "testDescription",
                 null,
                 "*",
+                "*",
                 SortMode.NONE);
 
         project.addProperty(new ParametersDefinitionProperty(def));
@@ -413,6 +421,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
                 "other",
                 "description",
                 "branch",
+                "*",
                 "*",
                 SortMode.NONE);
         job1.addProperty(new ParametersDefinitionProperty(gitParameterDefinition));


### PR DESCRIPTION
There's no reason to fetch the repository to list remote branches, if using git-ls-remote. The GitClient exposes that function, and offers significant performance increases when compared to a fetch/
branch -r" combination, especially for large repositories.

I made a separate pull request, since I feel liken this is a larger change than my other, which just fixes branch sorting and adds a filter for branches.
