### PR TITLE
use git-fetch with prune option

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -323,7 +323,7 @@ public class GitParameterDefinition extends ParameterDefinition implements
 				}
 
 				long time = -System.currentTimeMillis();
-				FetchCommand fetch = newgit.fetch_().from(remoteURL,
+				FetchCommand fetch = newgit.fetch_().prune().from(remoteURL,
 						repository.getFetchRefSpecs());
 				fetch.execute();
 				LOGGER.finest("Took " + (time + System.currentTimeMillis()) + "ms to fetch");

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -190,7 +190,7 @@ public class GitParameterDefinition extends ParameterDefinition implements
 
 	public void setBranchfilter(String branchfilter) {
 		if (isNullOrWhitespace(branchfilter)) {
-			branchfilter = "*";			
+			branchfilter = "*";
 		}
 		// Accept "*" as a wilcard
 		if (!"*".equals(branchfilter)) {
@@ -364,6 +364,10 @@ public class GitParameterDefinition extends ParameterDefinition implements
 						|| type.equalsIgnoreCase(PARAMETER_TYPE_TAG_BRANCH)) {
 					time = -System.currentTimeMillis();
 					Set<String> branchSet = new HashSet<String>();
+					String branchfilter = this.branchfilter;
+					if (branchfilter == null) {
+						branchfilter = "*";
+					}
 					final boolean wildcard = "*".equals(branchfilter);
 					for (Branch branch : newgit.getRemoteBranches()) {
 						// It'd be nice if we could filter on remote branches via the GitClient,

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -502,19 +502,24 @@ public class GitParameterDefinition extends ParameterDefinition implements
 			while (aIndex < a.length() && bIndex < b.length()) {
 				String aToken = getToken(a, aIndex);
 				String bToken = getToken(b, bIndex);
-				int difference;
+				long difference;
 
 				if (stringContainsInteger(aToken)
 						&& stringContainsInteger(bToken)) {
-					int aInt = Integer.parseInt(aToken);
-					int bInt = Integer.parseInt(bToken);
-					difference = aInt - bInt;
+					long aLong = Long.parseLong(aToken);
+					long bLong = Long.parseLong(bToken);
+					difference = aLong - bLong;
 				} else {
 					difference = aToken.compareTo(bToken);
 				}
 
-				if (difference != 0)
-					return difference;
+				if (difference != 0) {
+				    if (difference > 0) {
+					return 1;
+				    } else {
+					return -1;
+				    }
+				}
 
 				aIndex += aToken.length();
 				bIndex += bToken.length();

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
@@ -8,7 +8,7 @@
             </j:if>
             <st:adjunct includes="lib.form.select.select"/>
             <input type="hidden" name="name" value="${it.name}" />
-            <select name="value" class="select" size="5" width="200px"
+            <select name="value" class="select" size="25" width="200px"
                     fillUrl="${h.getCurrentDescriptorByNameUrl()}/${it.descriptor.descriptorUrl}/fillValueItems?param=${it.name}">
                 <option value="">${%Retrieving Git references…}</option>
             </select>


### PR DESCRIPTION
and remove any remote-tracking references that no longer exist on the remote. Tags are not subject to pruning if they are fetched only because of the default tag auto-following or due to a --tags option. However, if tags are fetched due to an explicit refspec (either on the command line or in the remote configuration, for example if the remote was cloned with the --mirror option), then they are also subject to pruning