### PR TITLE
Tag filter ignoring wildcards

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -345,7 +345,12 @@ public class GitParameterDefinition extends ParameterDefinition implements
 				if (type.equalsIgnoreCase(PARAMETER_TYPE_TAG)
 						|| type.equalsIgnoreCase(PARAMETER_TYPE_TAG_BRANCH)) {
 
-					Set<String> tagSet = newgit.getTagNames(tagFilter);
+					Set<String> tagSet;
+					if (tagFilter == null || "*".equals(tagFilter)) {
+						tagSet = newgit.getTagNames(null);
+					} else {
+						tagSet = newgit.getTagNames(tagFilter);
+					}
 					ArrayList<String> orderedTagNames;
 
 					if (this.getSortMode().getIsSorting()) {


### PR DESCRIPTION
The tag filter is not listing tags when a single \* wildcard is used due to incorrect syntax. This change corrects the problem by changing the git behavior from:
`git tag -l *`

to:
`git tag -l`

@reviewbybees
