### PR TITLE
Use long instead of integer

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -502,19 +502,24 @@ public class GitParameterDefinition extends ParameterDefinition implements
 			while (aIndex < a.length() && bIndex < b.length()) {
 				String aToken = getToken(a, aIndex);
 				String bToken = getToken(b, bIndex);
-				int difference;
+				long difference;
 
 				if (stringContainsInteger(aToken)
 						&& stringContainsInteger(bToken)) {
-					int aInt = Integer.parseInt(aToken);
-					int bInt = Integer.parseInt(bToken);
-					difference = aInt - bInt;
+					long aLong = Long.parseLong(aToken);
+					long bLong = Long.parseLong(bToken);
+					difference = aLong - bLong;
 				} else {
 					difference = aToken.compareTo(bToken);
 				}
 
-				if (difference != 0)
-					return difference;
+				if (difference != 0) {
+				    if (difference > 0) {
+					return 1;
+				    } else {
+					return -1;
+				    }
+				}
 
 				aIndex += aToken.length();
 				bIndex += bToken.length();


### PR DESCRIPTION
This avoids

  Caused by: java.lang.NumberFormatException: For input string: "20150122112449"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:48)
        at java.lang.Integer.parseInt(Integer.java:461)
        at java.lang.Integer.parseInt(Integer.java:499)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition$SmartNumberStringComparer.compare(GitParameterDefinition.java:485)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition$SmartNumberStringComparer.compare(GitParameterDefinition.java:428)
        at java.util.Arrays.mergeSort(Arrays.java:1270)
        at java.util.Arrays.mergeSort(Arrays.java:1282)
        at java.util.Arrays.mergeSort(Arrays.java:1281)
        at java.util.Arrays.mergeSort(Arrays.java:1281)
        at java.util.Arrays.mergeSort(Arrays.java:1281)
        at java.util.Arrays.mergeSort(Arrays.java:1281)
        at java.util.Arrays.sort(Arrays.java:1210)
        at java.util.Collections.sort(Collections.java:157)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition.sortByName(GitParameterDefinition.java:382)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition.generateContents(GitParameterDefinition.java:337)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition$DescriptorImpl.doFillValueItems(GitParameterDefinition.java:536)
        ... 83 more

In order to not overflow the int we just return -1/1 in case of a difference
since this enough for the Comparator interface.

Signed-off-by: Guido Günther <agx@sigxcpu.org>