### PR TITLE
remove the size of select setting for good showing branches

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
@@ -9,7 +9,7 @@
         <div name="parameter" description="${it.description}" id="${divId}">
             <st:adjunct includes="lib.form.select.select"/>
             <input type="hidden" name="name" value="${it.name}"/>
-            <select name="value" class="select" size="5" style="min-width: 200px" id="select"
+            <select name="value" class="select" style="min-width: 200px" id="select"
                     fillUrl="${h.getCurrentDescriptorByNameUrl()}/${it.descriptor.descriptorUrl}/fillValueItems?param=${it.name}">
                 <option value="">${%retrieving.references}</option>
             </select>


### PR DESCRIPTION
The default "5" for the size of select not good, removing it is good