### PR TITLE
Set browser focus to filter after the QuickFilter has been filled

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter.js
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter.js
@@ -99,7 +99,7 @@ var GitParameter = GitParameter || (function($) {
 
             _self.setSelected();
 
-            jQuery(_self.getFilterElement()).prop("disabled",false);
+            jQuery(_self.getFilterElement()).prop("disabled",false).focus();
             console.log("Quick Filter handler filled event." );
         });
 


### PR DESCRIPTION
This is a nice little fix to an annoyance my team had with this otherwise great plugin. It saves a click!