### PR TITLE
Extend list of supported type with pull request

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -41,6 +41,14 @@
                     <option value="PT_REVISION">${%parameter.revision}</option>
                 </j:otherwise>
             </j:choose>
+            <j:choose>
+                <j:when test="${instance.type eq 'PT_PULL_REQUEST'}">
+                    <option value="PT_PULL_REQUEST" selected="selected">${%parameter.pull.request}</option>
+                </j:when>
+                <j:otherwise>
+                    <option value="PT_PULL_REQUEST">${%parameter.pull.request}</option>
+                </j:otherwise>
+            </j:choose>
         </select>
     </f:entry>
 

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.properties
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.properties
@@ -7,6 +7,7 @@ parameter.branch=Branch
 parameter.branch.filter=Branch Filter
 parameter.branch.or.tag=Branch or Tag
 parameter.revision=Revision
+parameter.pull.request=Pull Request
 parameter.sort.mode=Sort Mode
 parameter.default.value=Default Value
 parameter.selected.value=Selected Value

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config_pl.properties
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config_pl.properties
@@ -7,6 +7,7 @@ parameter.branch=Branch
 parameter.branch.filter=Branch Filtr
 parameter.branch.or.tag=Branch lub Tag
 parameter.revision=Revision
+parameter.pull.request=Pull Request
 parameter.sort.mode=Rodzaj sortowania
 parameter.default.value=Domy\u015Blna warto\u015B\u0107
 parameter.selected.value=Zaznaczana warto\u015B\u0107


### PR DESCRIPTION
I would like to extend the git parameters with type **pull request**. 
The list will contain pull request ids for which the build could be scheduled.

It will allow me to schedule job for particular pull request not only with PullRequestBuilders but also on demand by selecting the id of pull request from parameter list. 