### PR TITLE
Add optional parameter to specify the number of items the list will display

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -241,7 +241,7 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
     }
 
     public String getListSize() {
-        return listSize;
+        return listSize == null ? DEFAULT_LIST_SIZE : listSize;
     }
 
     @DataBoundSetter

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -52,12 +52,14 @@ import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 public class GitParameterDefinition extends ParameterDefinition implements Comparable<GitParameterDefinition> {
     private static final long serialVersionUID = 9157832967140868122L;
 
+    private static final String DEFAULT_LIST_SIZE = "5";
     private static final String DEFAULT_REMOTE = "origin";
     private static final String REFS_TAGS_PATTERN = ".*refs/tags/";
 
@@ -83,6 +85,7 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
     private SelectedValue selectedValue;
     private String useRepository;
     private Boolean quickFilterEnabled;
+    private String listSize;
 
     @DataBoundConstructor
     public GitParameterDefinition(String name, String type, String defaultValue, String description, String branch,
@@ -95,6 +98,7 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
         this.sortMode = sortMode;
         this.selectedValue = selectedValue;
         this.quickFilterEnabled = quickFilterEnabled;
+        this.listSize = DEFAULT_LIST_SIZE;
 
         setUseRepository(useRepository);
         setType(type);
@@ -234,6 +238,15 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
         }
 
         this.branchFilter = branchFilter;
+    }
+
+    public String getListSize() {
+        return listSize;
+    }
+
+    @DataBoundSetter
+    public void setListSize(String listSize) {
+        this.listSize = listSize;
     }
 
     public SelectedValue getSelectedValue() {

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -84,5 +84,9 @@
         <f:entry title="${%parameter.quick.filter}" field="quickFilterEnabled">
             <f:checkbox/>
         </f:entry>
+
+        <f:entry title="${%parameter.list.size}" field="listSize">
+            <f:textbox default="5"/>
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.properties
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.properties
@@ -13,3 +13,4 @@ parameter.default.value=Default Value
 parameter.selected.value=Selected Value
 parameter.use.repository=Use repository
 parameter.quick.filter=Quick Filter
+parameter.list.size=List Size

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config_pl.properties
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config_pl.properties
@@ -13,3 +13,4 @@ parameter.default.value=Domy\u015Blna warto\u015B\u0107
 parameter.selected.value=Zaznaczana warto\u015B\u0107
 parameter.use.repository=U\u017Cyj repozytorium
 parameter.quick.filter=Szybkie filtrowanie
+parameter.list.size=Rozmiar Listy

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-listSize.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-listSize.html
@@ -1,0 +1,3 @@
+<div>
+    Specify the number of items the list will display.  A value of 0 will display as a DropDown list.
+</div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-listSize_fr.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-listSize_fr.html
@@ -1,0 +1,3 @@
+<div>
+    Indiquez le nombre d'éléments que la liste affichera. Une valeur de 0 s'affichera en tant que liste DropDown.
+</div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-listSize_pl.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-listSize_pl.html
@@ -1,0 +1,3 @@
+<div>
+    Określ liczbę elementów wyświetlanych na liście. Wartość 0 zostanie wyświetlona jako lista upuszczenia.
+</div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
@@ -9,7 +9,7 @@
         <div name="parameter" description="${it.description}" id="${divId}">
             <st:adjunct includes="lib.form.select.select"/>
             <input type="hidden" name="name" value="${it.name}"/>
-            <select name="value" class="select" size="5" style="min-width: 200px" id="select"
+            <select name="value" class="select" size="${it.listSize}" style="min-width: 200px" id="select"
                     fillUrl="${h.getCurrentDescriptorByNameUrl()}/${it.descriptor.descriptorUrl}/fillValueItems?param=${it.name}">
                 <option value="">${%retrieving.references}</option>
             </select>


### PR DESCRIPTION
Add optional list size parameter allowing user to define how many rows the GitParameter will display

Added translations where appropriate.  Note that translations were performed using Google Translate so they might need to be "tweaked" to be better understood by end French/Polish users.
 
JENKINS-49727