### PR TITLE
changed select element's id following previous fix in ae9de22

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
@@ -21,7 +21,7 @@
             </j:if>
             <script type="text/javascript">
                 var parentDiv = jQuery('#${divId}');
-                new GitParameter.QuickFilter(parentDiv.find('.select').get(0),
+                new GitParameter.QuickFilter(parentDiv.find('.gitParameterSelect').get(0),
                                              parentDiv.find('.git_parameter_quick_filter').get(0),
                                              "${it.selectedValue}", "${it.defaultValue}");
             </script>


### PR DESCRIPTION
Fixes an issue created in ae9de22, the element id was changed but not changed in the following jQuery search, leading to an issue where the "Filter" element would remain disabled even after the select element has been "filled" since the select element itself could not be found