### PR TITLE
Check for null remote URLs

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/SCMFactory.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/SCMFactory.java
@@ -54,7 +54,8 @@ public class SCMFactory {
     private static boolean anyUserRemoteConfigMatch(SCM scm, Pattern repositoryNamePattern) {
         List<UserRemoteConfig> userRemoteConfigs = ((GitSCM) scm).getUserRemoteConfigs();
         for (UserRemoteConfig userRemoteConfig : userRemoteConfigs) {
-            if (repositoryNamePattern.matcher(userRemoteConfig.getUrl()).find()) {
+            String remoteUrl = userRemoteConfig.getUrl();
+            if (remoteUrl != null && repositoryNamePattern.matcher(remoteUrl).find()) {
                 return true;
             }
         }


### PR DESCRIPTION
This could be the issue seen by JENKINS-50014. Where a remote URL is null and when a pattern is set attempts to match to a null string which gives the stack trace.
```
Caused by: java.lang.NullPointerException
        at java.util.regex.Matcher.getTextLength(Matcher.java:1283)
        at java.util.regex.Matcher.reset(Matcher.java:309)
        at java.util.regex.Matcher.<init>(Matcher.java:229)
        at java.util.regex.Pattern.matcher(Pattern.java:1093)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.scms.SCMFactory.anyUserRemoteConfigMatch(SCMFactory.java:57)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.scms.SCMFactory.matchAndGetGitSCM(SCMFactory.java:47)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.scms.SCMFactory.getGitSCMs(SCMFactory.java:40)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition$DescriptorImpl.getProjectSCMs(GitParameterDefinition.java:621)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition$DescriptorImpl.doFillValueItems(GitParameterDefinition.java:602)
        at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
        at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:396)
        at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:408)
        at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:212)
        at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:145)
        at org.kohsuke.stapler.MetaClass$11.doDispatch(MetaClass.java:535)
        at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:747)
```
RemoteURL can be null as seen from
https://github.com/jenkinsci/git-plugin/blob/fcd163d443aa11dd59c3fd937f78768a06a61316/src/main/java/hudson/plugins/git/UserRemoteConfig.java#L54
@klimas7 could you PTAL