### PR TITLE
Don't perform 'git' step with different repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ pipeline {
         stage('Example') {
             steps {
                 git url: 'https://github.com/klimas7/exampleA.git'
-		dir('dir-for-exampleB') {
+                dir('dir-for-exampleB') {
                     git url: 'https://github.com/klimas7/exampleB.git'
 		}
             }

--- a/README.md
+++ b/README.md
@@ -344,7 +344,9 @@ pipeline {
         stage('Example') {
             steps {
                 git url: 'https://github.com/klimas7/exampleA.git'
-                git url: 'https://github.com/klimas7/exampleB.git'
+		dir('dir-for-exampleB') {
+                    git url: 'https://github.com/klimas7/exampleB.git'
+		}
             }
         }
     }


### PR DESCRIPTION
The `git` step and the `checkout scm` step assume that a workspace represents a single git remote.  The example uses two different repos in the same workspace directory.  That will confuse the user and confuse the git plugin, since it will likely force the workspace to have the checkout of the second repository, even though the first was  fetched immediately prior to the fetch of the first repository.