### PR TITLE
fixes exception when trimming long message not containing spaces

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/RevisionInfoFactory.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/RevisionInfoFactory.java
@@ -106,6 +106,9 @@ public class RevisionInfoFactory {
     private String trimMessage(String commitMessage) {
         if (commitMessage.length() > MAX_COMMIT_MESSAGE_LENGTH) {
             int lastSpace = commitMessage.lastIndexOf(" ", MAX_COMMIT_MESSAGE_LENGTH);
+            if (lastSpace == -1) {
+                lastSpace = MAX_COMMIT_MESSAGE_LENGTH;
+            }
             return commitMessage.substring(0, lastSpace) + " ...";
         }
         return commitMessage;


### PR DESCRIPTION
Original issue stack trace:
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
        at java.lang.String.substring(String.java:1967)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.RevisionInfoFactory.trimMessage(RevisionInfoFactory.java:109)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.RevisionInfoFactory.prettyRevisionInfo(RevisionInfoFactory.java:64)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.RevisionInfoFactory.getRevisions(RevisionInfoFactory.java:47)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition.getRevision(GitParameterDefinition.java:423)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition.generateContents(GitParameterDefinition.java:309)
        at net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition$DescriptorImpl.doFillValueItems(GitParameterDefinition.java:618)
        at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)