### PR TITLE
Fix validation for the new Jenkins form validation JS

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter-select.js
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter-select.js
@@ -5,7 +5,8 @@ function gitParameterUpdateSelect(listBox, url, divId, config) {
     config = object(config);
     var originalOnSuccess = config.onSuccess;
     var l = $(listBox);
-    var status = findFollowingTR(listBox, "validation-error-area").firstChild.nextSibling;
+    // TODO - Remove
+    var status = findFollowingTR(listBox, "validation-error-area") || findFollowingTR(listBox, "validation-error-area").firstChild.nextSibling;
     if (status.firstChild && status.firstChild.getAttribute('data-select-ajax-error')) {
         status.innerHTML = "";
     }
@@ -49,7 +50,7 @@ function gitParameterUpdateSelect(listBox, url, divId, config) {
             $error_ul.update(lis);
         }
         else {
-            $error_div.hide()
+            error_div.hide()
         }
 
     };

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter-select.js
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter-select.js
@@ -5,7 +5,7 @@ function gitParameterUpdateSelect(listBox, url, divId, config) {
     config = object(config);
     var originalOnSuccess = config.onSuccess;
     var l = $(listBox);
-    // TODO - Remove
+    // TODO - Remove the null check once this plugin targets https://github.com/jenkinsci/jenkins/pull/6460 or higher
     var status = findFollowingTR(listBox, "validation-error-area") || findFollowingTR(listBox, "validation-error-area").firstChild.nextSibling;
     if (status.firstChild && status.firstChild.getAttribute('data-select-ajax-error')) {
         status.innerHTML = "";

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter-select.js
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter-select.js
@@ -5,8 +5,8 @@ function gitParameterUpdateSelect(listBox, url, divId, config) {
     config = object(config);
     var originalOnSuccess = config.onSuccess;
     var l = $(listBox);
-    // TODO - Remove the null check once this plugin targets https://github.com/jenkinsci/jenkins/pull/6460 or higher
-    var status = findFollowingTR(listBox, "validation-error-area") || findFollowingTR(listBox, "validation-error-area").firstChild.nextSibling;
+    // TODO - Remove '.firstChild?.nextSibling' once this plugin targets https://github.com/jenkinsci/jenkins/pull/6460 or higher
+    var status = findFollowingTR(listBox, "validation-error-area").firstChild?.nextSibling || findFollowingTR(listBox, "validation-error-area");
     if (status.firstChild && status.firstChild.getAttribute('data-select-ajax-error')) {
         status.innerHTML = "";
     }


### PR DESCRIPTION
As part of https://github.com/jenkinsci/jenkins/pull/6460 the Jenkins form validation JS is changing to simplify its logic. This PR fixes this plugin so that it'll work correctly with both the old validation JS and the new validation JS.

---

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
