### PR TITLE
Add UI Acceptance test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,18 @@
 			<artifactId>matrix-project</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-java</artifactId>
+			<version>4.10.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.bonigarcia</groupId>
+			<artifactId>webdrivermanager</artifactId>
+			<version>5.3.3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<scm>
@@ -125,6 +137,33 @@
 		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 	  <tag>HEAD</tag>
-  </scm>
+	</scm>
+
+	<profiles>
+		<profile>
+			<id>windows-ci</id>
+			<activation>
+				<os>
+					<family>Windows</family>
+				</os>
+				<property>
+					<name>env.CI</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<!-- TODO fails on CI on Windows for inscrutable reasons -->
+							<excludes>
+								<exclude>net.uaznia.lukanus.hudson.plugins.gitparameter.UiAcceptanceTest</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/UiAcceptanceTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/UiAcceptanceTest.java
@@ -1,0 +1,86 @@
+package net.uaznia.lukanus.hudson.plugins.gitparameter;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.apache.commons.lang.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+public class UiAcceptanceTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private WebDriver driver;
+
+    @BeforeClass
+    public static void setUpClass() {
+        if (isCi()) {
+            // The browserVersion needs to match what is provided by the Jenkins Infrastructure
+            // If you see an exception like this:
+            //
+            // org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: session not created: This version of ChromeDriver only supports Chrome version 114
+            // Current browser version is 112.0.5615.49 with binary path /usr/bin/chromium-browser
+            //
+            // Then that means you need to update the version here to match the current browser version.
+            WebDriverManager.chromedriver().browserVersion("112").setup();
+        } else {
+            WebDriverManager.chromedriver().setup();
+        }
+    }
+
+    private static boolean isCi() {
+        return StringUtils.isNotBlank(System.getenv("CI"));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        if (isCi()) {
+            driver = new ChromeDriver(new ChromeOptions().addArguments("--headless", "--disable-dev-shm-usage", "--no-sandbox"));
+        } else {
+            driver = new ChromeDriver(new ChromeOptions());
+        }
+    }
+
+    @After
+    public void tearDown() {
+        driver.quit();
+    }
+
+    @LocalData
+    @Test
+    public void test() throws Exception {
+        driver.get(j.getURL().toString() + "job/test/build");
+
+        WebElement branchParam = driver.findElement(byParamName("Branch"));
+        WebElement tagParam = driver.findElement(byParamName("Tag"));
+        WebElement revisionParam = driver.findElement(byParamName("Revision"));
+
+        new WebDriverWait(driver, Duration.ofSeconds(60))
+                .until(driver1 -> new Select(driver1.findElement(byParamName("Revision"))).getOptions().size() > 1);
+
+        assertTrue(new Select(branchParam).getOptions().stream().anyMatch(option -> option.getAttribute("value").equals("origin/master")));
+        assertTrue(new Select(tagParam).getOptions().stream().anyMatch(option -> option.getAttribute("value").equals("git-parameter-0.9.7")));
+        assertTrue(new Select(revisionParam).getOptions().stream().anyMatch(option -> option.getAttribute("value").equals("00a8385cba1e4e32cf823775e2b3dbe5eb27931d")));
+
+    }
+
+    private static By byParamName(String paramName) {
+        return By.cssSelector("div[name='parameter']:has([name='name'][value='" + paramName + "']) > select");
+    }
+
+}

--- a/src/test/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/UiAcceptanceTest/test/jobs/test/config.xml
+++ b/src/test/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/UiAcceptanceTest/test/jobs/test/config.xml
@@ -1,0 +1,83 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.32">
+            <autoRebuild>false</autoRebuild>
+            <rebuildDisabled>false</rebuildDisabled>
+        </com.sonyericsson.rebuild.RebuildSettings>
+        <hudson.model.ParametersDefinitionProperty>
+            <parameterDefinitions>
+                <net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition plugin="git-parameter@0.9.19-SNAPSHOT">
+                    <name>Branch</name>
+                    <uuid>47b5ed4f-09f1-4825-afe1-f32fcc4925d3</uuid>
+                    <type>PT_BRANCH</type>
+                    <branch></branch>
+                    <tagFilter>*</tagFilter>
+                    <branchFilter>.*</branchFilter>
+                    <sortMode>NONE</sortMode>
+                    <defaultValue>main</defaultValue>
+                    <selectedValue>NONE</selectedValue>
+                    <quickFilterEnabled>false</quickFilterEnabled>
+                    <listSize>5</listSize>
+                    <requiredParameter>false</requiredParameter>
+                </net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition>
+                <net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition plugin="git-parameter@0.9.19-SNAPSHOT">
+                    <name>Tag</name>
+                    <uuid>a7d476bb-5cfe-47db-b9e8-a3e8737f37d9</uuid>
+                    <type>PT_TAG</type>
+                    <branch></branch>
+                    <tagFilter>*</tagFilter>
+                    <branchFilter>.*</branchFilter>
+                    <sortMode>NONE</sortMode>
+                    <defaultValue>0.1</defaultValue>
+                    <selectedValue>NONE</selectedValue>
+                    <quickFilterEnabled>false</quickFilterEnabled>
+                    <listSize>5</listSize>
+                    <requiredParameter>false</requiredParameter>
+                </net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition>
+                <net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition plugin="git-parameter@0.9.19-SNAPSHOT">
+                    <name>Revision</name>
+                    <uuid>81de79f5-21ee-4e09-b9a4-b11460de0a04</uuid>
+                    <type>PT_REVISION</type>
+                    <branch>origin/master</branch>
+                    <tagFilter>*</tagFilter>
+                    <branchFilter>.*</branchFilter>
+                    <sortMode>NONE</sortMode>
+                    <defaultValue></defaultValue>
+                    <selectedValue>NONE</selectedValue>
+                    <quickFilterEnabled>false</quickFilterEnabled>
+                    <listSize>5</listSize>
+                    <requiredParameter>false</requiredParameter>
+                </net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition>
+            </parameterDefinitions>
+        </hudson.model.ParametersDefinitionProperty>
+    </properties>
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.11.2">
+        <configVersion>2</configVersion>
+        <userRemoteConfigs>
+            <hudson.plugins.git.UserRemoteConfig>
+                <url>https://github.com/jenkinsci/git-parameter-plugin.git</url>
+            </hudson.plugins.git.UserRemoteConfig>
+        </userRemoteConfigs>
+        <branches>
+            <hudson.plugins.git.BranchSpec>
+                <name>*/master</name>
+            </hudson.plugins.git.BranchSpec>
+        </branches>
+        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+        <submoduleCfg class="empty-list"/>
+        <extensions/>
+    </scm>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders/>
+    <publishers/>
+    <buildWrappers/>
+</project>


### PR DESCRIPTION
This should help validate Jelly and javascript changes.
This is layered on top of #96. That is required to get the most recent versions of dependencies added. Otherwise transitives go over the max upper bound.

### Testing done

This is a pure test addition. I plan to use this to validate [JENKINS-71298](https://issues.jenkins.io/browse/JENKINS-71298).

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
