### PR TITLE
refactor: Do not rely on prototype.js

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter-select.js
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter-select.js
@@ -4,74 +4,103 @@ function gitParameterUpdateSelect(listBox, url, divId, config) {
     config = config || {};
     config = object(config);
     var originalOnSuccess = config.onSuccess;
-    var l = $(listBox);
+    // TODO Inline this variable, maybe?
+    var l = listBox;
     // TODO - Remove '.firstChild?.nextSibling' once this plugin targets https://github.com/jenkinsci/jenkins/pull/6460 or higher
     var status = findFollowingTR(listBox, "validation-error-area").firstChild?.nextSibling || findFollowingTR(listBox, "validation-error-area");
     if (status.firstChild && status.firstChild.getAttribute('data-select-ajax-error')) {
         status.innerHTML = "";
     }
     config.onSuccess = function (rsp) {
-        l.removeClassName("select-ajax-pending");
-        var currentSelection = l.value;
+        rsp.json().then(json => {
+            l.classList.remove("select-ajax-pending");
+            var currentSelection = l.value;
 
-        // clear the contents
-        while (l.length > 0) l.options[0] = null;
-
-        var selectionSet = false; // is the selection forced by the server?
-        var possibleIndex = null; // if there's a new option that matches the current value, remember its index
-        var opts = eval('(' + rsp.responseText + ')').values;
-        for (var i = 0; i < opts.length; i++) {
-            l.options[i] = new Option(opts[i].name, opts[i].value);
-            if (opts[i].selected) {
-                l.selectedIndex = i;
-                selectionSet = true;
-            }
-            if (opts[i].value === currentSelection)
-                possibleIndex = i;
-        }
-
-        // if no value is explicitly selected by the server, try to select the same value
-        if (!selectionSet && possibleIndex != null)
-            l.selectedIndex = possibleIndex;
-
-        if (originalOnSuccess !== undefined)
-            originalOnSuccess(rsp);
-
-        var errors = eval('(' + rsp.responseText + ')').errors
-        let error_div = $("git_parameter_errors_" + divId);
-        if (errors.length !== 0) {
-            error_div.show();
-            error_div.addClassName("error");
-            let $error_ul = $("git_parameter_errors_ul_" + divId);
-            var lis = "";
-            for (var j = 0; j < errors.length; j++) {
-                lis += "<li>" + escapeHTML(errors[j]) + "</li>"
-            }
-            $error_ul.update(lis);
-        }
-        else {
-            error_div.hide()
-        }
-
-    };
-    config.onFailure = function (rsp) {
-        l.removeClassName("select-ajax-pending");
-        status.innerHTML = rsp.responseText;
-        if (status.firstChild) {
-            status.firstChild.setAttribute('data-select-ajax-error', 'true')
-        }
-        Behaviour.applySubtree(status);
-        // deleting values can result in the data loss, so let's not do that unless instructed
-        var header = rsp.getResponseHeader('X-Jenkins-Select-Error');
-        if (header && "clear" === header.toLowerCase()) {
             // clear the contents
             while (l.length > 0) l.options[0] = null;
-        }
+
+            var selectionSet = false; // is the selection forced by the server?
+            var possibleIndex = null; // if there's a new option that matches the current value, remember its index
+            var opts = json.values;
+            for (var i = 0; i < opts.length; i++) {
+                l.options[i] = new Option(opts[i].name, opts[i].value);
+                if (opts[i].selected) {
+                    l.selectedIndex = i;
+                    selectionSet = true;
+                }
+                if (opts[i].value === currentSelection)
+                    possibleIndex = i;
+            }
+
+            // if no value is explicitly selected by the server, try to select the same value
+            if (!selectionSet && possibleIndex != null)
+                l.selectedIndex = possibleIndex;
+
+            if (originalOnSuccess !== undefined)
+                originalOnSuccess(rsp);
+
+            var errors = json.errors
+            let error_div = document.getElementById("git_parameter_errors_" + divId);
+            if (errors.length !== 0) {
+                error_div.style.display = "";
+                error_div.classList.add("error");
+                let $error_ul = document.getElementById("git_parameter_errors_ul_" + divId);
+                var lis = "";
+                for (var j = 0; j < errors.length; j++) {
+                    lis += "<li>" + escapeHTML(errors[j]) + "</li>"
+                }
+                $error_ul.innerHTML = lis;
+            } else {
+                error_div.style.display = "none";
+            }
+        });
+    };
+    config.onFailure = function (rsp) {
+        rsp.text().then(text => {
+            l.classList.remove("select-ajax-pending");
+            status.innerHTML = text;
+            if (status.firstChild) {
+                status.firstChild.setAttribute('data-select-ajax-error', 'true')
+            }
+            Behaviour.applySubtree(status);
+            // deleting values can result in the data loss, so let's not do that unless instructed
+            var header = rsp.headers.get('X-Jenkins-Select-Error');
+            if (header && "clear" === header.toLowerCase()) {
+                // clear the contents
+                while (l.length > 0) l.options[0] = null;
+            }
+        });
 
     };
 
-    l.addClassName("select-ajax-pending");
-    new Ajax.Request(url, config);
+    l.classList.add("select-ajax-pending");
+
+    fetch(url, {
+        method: 'POST',
+        body: objectToUrlFormEncoded(config.parameters),
+        headers: crumb.wrap({
+          "Content-Type": "application/x-www-form-urlencoded"
+        })
+    }).then((response) => {
+        if (response.ok) {
+            config.onSuccess(response);
+        } else {
+            config.onFailure(response);
+        }
+    });
+}
+
+/*
+ * Copied over from core - see https://github.com/jenkinsci/git-parameter-plugin/pull/98#discussion_r1246920397
+ */
+function objectToUrlFormEncoded(parameters) {
+  let formBody = [];
+  for (const property in parameters) {
+    const encodedKey = encodeURIComponent(property);
+    const encodedValue = encodeURIComponent(parameters[property]);
+    formBody.push(encodedKey + "=" + encodedValue);
+  }
+  return formBody.join("&");
 }
 
 Behaviour.specify("SELECT.gitParameterSelect", 'gitParameterSelect', 1000, function (e) {

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter.js
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/javascript/git-parameter.js
@@ -127,8 +127,7 @@ var GitParameter = GitParameter || (function($) {
             var regex = new RegExp(search,"gi");
 
             var filteredOptions = Array();
-            $.each(originalOptions, function(i) {
-                var option = originalOptions[i];
+            originalOptions.forEach(option => {
                 if(option.text.match(regex) !== null) {
                     filteredOptions.push(option)
                 }


### PR DESCRIPTION
Jenkins has been using a very old version of Prototype.js. Starting with 2.406 of Jenkins, prototype is being gradually removed.

This change removes direct calls to prototype in the git-parameter plugin.

Refs: [JENKINS-71298](https://issues.jenkins.io/browse/JENKINS-71298)

<!-- Please describe your pull request here. -->

### Testing done

I've got another PR open (#97) that verifies the UI still works.
I ran the `find` command suggested in the ticket - and it only shows a call to jQuery left after this.


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
