### PR TITLE
Format project with Spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
     <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/Consts.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/Consts.java
@@ -19,8 +19,10 @@ public class Consts {
     public static final String EMPTY_JOB_NAME = "EMPTY_JOB_NAME";
 
     public static boolean isParameterTypeCorrect(String type) {
-        return type.equals(PARAMETER_TYPE_TAG) || type.equals(PARAMETER_TYPE_REVISION)
-                || type.equals(PARAMETER_TYPE_BRANCH) || type.equals(PARAMETER_TYPE_TAG_BRANCH)
+        return type.equals(PARAMETER_TYPE_TAG)
+                || type.equals(PARAMETER_TYPE_REVISION)
+                || type.equals(PARAMETER_TYPE_BRANCH)
+                || type.equals(PARAMETER_TYPE_TAG_BRANCH)
                 || type.equals(PARAMETER_TYPE_PULL_REQUEST);
     }
 

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/FilePathWrapper.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/FilePathWrapper.java
@@ -1,8 +1,7 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
-import java.io.IOException;
-
 import hudson.FilePath;
+import java.io.IOException;
 
 public class FilePathWrapper {
     private final FilePath filePath;

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterRebuild.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterRebuild.java
@@ -11,7 +11,7 @@ public class GitParameterRebuild extends RebuildParameterProvider {
     @Override
     public RebuildParameterPage getRebuildPage(ParameterValue parameterValue) {
         if (parameterValue instanceof GitParameterValue) {
-            return new RebuildParameterPage(parameterValue.getClass(),"value.jelly");
+            return new RebuildParameterPage(parameterValue.getClass(), "value.jelly");
         }
         return null;
     }

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterValue.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterValue.java
@@ -1,8 +1,7 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import hudson.model.StringParameterValue;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 public class GitParameterValue extends StringParameterValue {
     private static final long serialVersionUID = -8244244942726975701L;

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/RevisionInfoFactory.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/RevisionInfoFactory.java
@@ -1,22 +1,22 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
-import static java.lang.Long.parseLong;
-
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.Revision;
-import org.apache.commons.lang.StringUtils;
-import org.eclipse.jgit.lib.ObjectId;
-import org.jenkinsci.plugins.gitclient.GitClient;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.gitclient.GitClient;
 
 public class RevisionInfoFactory {
 
@@ -71,16 +71,19 @@ public class RevisionInfoFactory {
             String author = matcher.group(1);
             String timestamp = matcher.group(2);
             String zone = matcher.group(3);
-            LocalDateTime date = LocalDateTime.ofInstant(Instant.ofEpochMilli(parseLong(timestamp) * 1000), ZoneId.of(zone));
+            LocalDateTime date =
+                    LocalDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(timestamp) * 1000), ZoneId.of(zone));
             String stringDate = date.format(DATE_FORMAT);
-            return StringUtils.join(new Object[]{shortSha1, stringDate, author, commitMessage}, " ").trim();
+            return StringUtils.join(new Object[] {shortSha1, stringDate, author, commitMessage}, " ")
+                    .trim();
         }
 
         matcher = AUTHOR_LINE_PATTERN_GENERAL_DATE.matcher(authorLine);
         if (matcher.find()) {
             String author = matcher.group(1);
             String date = matcher.group(2);
-            return StringUtils.join(new Object[]{shortSha1, date, author, commitMessage}, " ").trim();
+            return StringUtils.join(new Object[] {shortSha1, date, author, commitMessage}, " ")
+                    .trim();
         }
 
         LOGGER.log(Level.WARNING, Messages.GitParameterDefinition_notFindAuthorPattern(authorLine));

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SelectedValue.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SelectedValue.java
@@ -1,5 +1,7 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
 public enum SelectedValue {
-    NONE, TOP, DEFAULT
+    NONE,
+    TOP,
+    DEFAULT
 }

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SmartNumberStringComparer.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SmartNumberStringComparer.java
@@ -19,19 +19,21 @@ class SmartNumberStringComparer implements Comparator<String>, Serializable {
      */
     private String getToken(String str, int index) {
         char nextChar = str.charAt(index++);
-        StringBuilder token =  new StringBuilder(String.valueOf(nextChar));
+        StringBuilder token = new StringBuilder(String.valueOf(nextChar));
 
         // if the first char wasn't a digit then we're already done
-        if (!Character.isDigit(nextChar))
+        if (!Character.isDigit(nextChar)) {
             return token.toString();
+        }
 
         // the first char was a digit so continue until end of string or non
         // digit
         while (index < str.length()) {
             nextChar = str.charAt(index++);
 
-            if (!Character.isDigit(nextChar))
+            if (!Character.isDigit(nextChar)) {
                 break;
+            }
 
             token.append(nextChar);
         }
@@ -44,12 +46,14 @@ class SmartNumberStringComparer implements Comparator<String>, Serializable {
      */
     private boolean stringContainsInteger(String str) {
         for (int charIndex = 0; charIndex < str.length(); charIndex++) {
-            if (!Character.isDigit(str.charAt(charIndex)))
+            if (!Character.isDigit(str.charAt(charIndex))) {
                 return false;
+            }
         }
         return true;
     }
 
+    @Override
     public int compare(String a, String b) {
 
         int aIndex = 0;
@@ -60,8 +64,7 @@ class SmartNumberStringComparer implements Comparator<String>, Serializable {
             String bToken = getToken(b, bIndex);
             int difference;
 
-            if (stringContainsInteger(aToken)
-                    && stringContainsInteger(bToken)) {
+            if (stringContainsInteger(aToken) && stringContainsInteger(bToken)) {
                 BigInteger aInt = new BigInteger(aToken);
                 BigInteger bInt = new BigInteger(bToken);
                 difference = aInt.compareTo(bInt);
@@ -69,8 +72,9 @@ class SmartNumberStringComparer implements Comparator<String>, Serializable {
                 difference = aToken.compareTo(bToken);
             }
 
-            if (difference != 0)
+            if (difference != 0) {
                 return difference;
+            }
 
             aIndex += aToken.length();
             bIndex += bToken.length();
@@ -78,5 +82,4 @@ class SmartNumberStringComparer implements Comparator<String>, Serializable {
 
         return Integer.compare(a.length(), b.length());
     }
-
 }

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SortMode.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SortMode.java
@@ -1,7 +1,11 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
 enum SortMode {
-    NONE, ASCENDING_SMART, DESCENDING_SMART, ASCENDING, DESCENDING;
+    NONE,
+    ASCENDING_SMART,
+    DESCENDING_SMART,
+    ASCENDING,
+    DESCENDING;
 
     public boolean getIsUsingSmartSort() {
         return this == ASCENDING_SMART || this == DESCENDING_SMART;

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/Utils.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/Utils.java
@@ -4,9 +4,8 @@ import hudson.model.Job;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.TopLevelItem;
-import jenkins.model.Jenkins;
-
 import java.util.List;
+import jenkins.model.Jenkins;
 
 public class Utils {
 
@@ -19,8 +18,10 @@ public class Utils {
                 .orElse(null);
     }
 
-    private static boolean haveThisGitParameterDefinition(final Job job, final GitParameterDefinition gitParameterDefinition) {
-        ParametersDefinitionProperty property = (ParametersDefinitionProperty) job.getProperty(ParametersDefinitionProperty.class);
+    private static boolean haveThisGitParameterDefinition(
+            final Job job, final GitParameterDefinition gitParameterDefinition) {
+        ParametersDefinitionProperty property =
+                (ParametersDefinitionProperty) job.getProperty(ParametersDefinitionProperty.class);
         List<ParameterDefinition> parameterDefinitions = property.getParameterDefinitions();
 
         if (parameterDefinitions != null) {

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/AbstractJobWrapper.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/AbstractJobWrapper.java
@@ -1,13 +1,11 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.jobs;
 
-
-import java.io.IOException;
-
 import hudson.EnvVars;
 import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.TaskListener;
+import java.io.IOException;
 
 public abstract class AbstractJobWrapper implements JobWrapper {
     private Job job;

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/AbstractProjectJobWrapper.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/AbstractProjectJobWrapper.java
@@ -1,10 +1,5 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.jobs;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
@@ -12,6 +7,10 @@ import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class AbstractProjectJobWrapper extends AbstractJobWrapper {
     private static final Logger LOGGER = Logger.getLogger(AbstractProjectJobWrapper.class.getName());

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/JobWrapper.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/JobWrapper.java
@@ -1,8 +1,5 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.jobs;
 
-import java.io.IOException;
-import java.util.List;
-
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.Job;
@@ -10,6 +7,8 @@ import hudson.model.Node;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
+import java.io.IOException;
+import java.util.List;
 
 public interface JobWrapper {
     Job getJob();

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/JobWrapperFactory.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/JobWrapperFactory.java
@@ -12,7 +12,8 @@ public class JobWrapperFactory {
         } else if (isWorkflowJob(job)) {
             return new WorkflowJobWrapper(job);
         }
-        throw new UnsupportedJobType(Messages.JobWrapperFactory_UnsupportedJobType(job.getClass().getName()));
+        throw new UnsupportedJobType(
+                Messages.JobWrapperFactory_UnsupportedJobType(job.getClass().getName()));
     }
 
     private static boolean isWorkflowJob(Job job) {

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/WorkflowJobWrapper.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/jobs/WorkflowJobWrapper.java
@@ -1,5 +1,12 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.jobs;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.Job;
+import hudson.model.TaskListener;
+import hudson.model.TopLevelItem;
+import hudson.scm.SCM;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -8,14 +15,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.model.Job;
-import hudson.model.TaskListener;
-import hudson.model.TopLevelItem;
-import hudson.scm.SCM;
 import jenkins.model.Jenkins;
 
 public class WorkflowJobWrapper extends AbstractJobWrapper {
@@ -48,11 +47,11 @@ public class WorkflowJobWrapper extends AbstractJobWrapper {
                 return (Collection<? extends SCM>) scms;
             }
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, getCustomJobName() + " " + Messages.WorkflowJobWrapper_GetWorkflowRepoScmFail(), e);
+            LOGGER.log(
+                    Level.SEVERE, getCustomJobName() + " " + Messages.WorkflowJobWrapper_GetWorkflowRepoScmFail(), e);
         }
         return null;
     }
-
 
     private SCM getSCMFromDefinition() {
         try {
@@ -69,15 +68,19 @@ public class WorkflowJobWrapper extends AbstractJobWrapper {
                 return (SCM) scm;
             }
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, getCustomJobName() + " " + Messages.WorkflowJobWrapper_GetWorkflowRepoScmFail(), e);
+            LOGGER.log(
+                    Level.SEVERE, getCustomJobName() + " " + Messages.WorkflowJobWrapper_GetWorkflowRepoScmFail(), e);
         }
         return null;
     }
 
     @Override
-    @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification="Jenkins.getInstance() is not null")
+    @SuppressFBWarnings(
+            value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            justification = "Jenkins.getInstance() is not null")
     public FilePath getSomeWorkspace() throws IOException, InterruptedException {
-        FilePath workspaceForWorkflow = Jenkins.get().getWorkspaceFor((TopLevelItem) getJob()).withSuffix("@script");
+        FilePath workspaceForWorkflow =
+                Jenkins.get().getWorkspaceFor((TopLevelItem) getJob()).withSuffix("@script");
         if (workspaceForWorkflow.exists()) {
             return workspaceForWorkflow;
         }
@@ -98,7 +101,8 @@ public class WorkflowJobWrapper extends AbstractJobWrapper {
                 }
             }
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, getCustomJobName() + Messages.WorkflowJobWrapper_GetEnvironmentsFromWorkflowrun(), e);
+            LOGGER.log(
+                    Level.SEVERE, getCustomJobName() + Messages.WorkflowJobWrapper_GetEnvironmentsFromWorkflowrun(), e);
         }
         return null;
     }
@@ -107,7 +111,8 @@ public class WorkflowJobWrapper extends AbstractJobWrapper {
         return !"org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition".equals(clazz.getName());
     }
 
-    private Object invokeGetMethodFromJob(String methodInvoke) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    private Object invokeGetMethodFromJob(String methodInvoke)
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Class<?> workflowJobClazz = getJob().getClass();
         Method getDefinitionMethod = workflowJobClazz.getDeclaredMethod(methodInvoke);
         return getDefinitionMethod.invoke(getJob());

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/model/ItemsErrorModel.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/model/ItemsErrorModel.java
@@ -1,5 +1,9 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.model;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.ServletException;
 import jenkins.security.stapler.StaplerAccessibleType;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.HttpResponse;
@@ -8,11 +12,6 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.export.Flavor;
-
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @ExportedBean(defaultVisibility = 4)
 @StaplerAccessibleType
@@ -23,6 +22,7 @@ public class ItemsErrorModel implements HttpResponse {
     public static final class Option {
         @Exported
         public String name;
+
         @Exported
         public String value;
 
@@ -43,6 +43,7 @@ public class ItemsErrorModel implements HttpResponse {
 
     @Exported
     public List<Option> values = new ArrayList<>();
+
     @Exported
     public List<String> errors = new ArrayList<>();
 
@@ -79,7 +80,8 @@ public class ItemsErrorModel implements HttpResponse {
     }
 
     @Override
-    public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
+    public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node)
+            throws IOException, ServletException {
         writeTo(req, rsp);
     }
 

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/EmptySCM.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/EmptySCM.java
@@ -1,9 +1,8 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.scms;
 
+import hudson.scm.SCM;
 import java.util.Collections;
 import java.util.List;
-
-import hudson.scm.SCM;
 
 public class EmptySCM implements SCMWrapper {
     @Override

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/MultiSCM.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/MultiSCM.java
@@ -1,11 +1,10 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.scms;
 
+import hudson.scm.SCM;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import hudson.scm.SCM;
 
 public class MultiSCM implements SCMWrapper {
     public static final String MULTI_SCM_CLASS_NAME = "org.jenkinsci.plugins.multiplescms.MultiSCM";
@@ -18,7 +17,7 @@ public class MultiSCM implements SCMWrapper {
 
     @Override
     public List<SCM> getSCMs() {
-        //((MultiSCM)scm).getConfiguredSCMs()
+        // ((MultiSCM)scm).getConfiguredSCMs()
         try {
             Class<?> clazz = scm.getClass();
             Method getProjectScmMethod = clazz.getDeclaredMethod("getConfiguredSCMs");

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/ProxySCM.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/ProxySCM.java
@@ -1,12 +1,11 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.scms;
 
+import hudson.scm.SCM;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import hudson.scm.SCM;
 
 public class ProxySCM implements SCMWrapper {
     public static final String PROXY_SCM_CLASS_NAME = "hudson.plugins.templateproject.ProxySCM";
@@ -19,7 +18,7 @@ public class ProxySCM implements SCMWrapper {
 
     @Override
     public List<SCM> getSCMs() {
-        //((ProxySCM)projectScm).getProjectScm()
+        // ((ProxySCM)projectScm).getProjectScm()
         try {
             Class<?> clazz = scm.getClass();
             Method getProjectScmMethod = clazz.getDeclaredMethod("getProjectScm");

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/RepoSCM.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/RepoSCM.java
@@ -1,15 +1,14 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.scms;
 
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import hudson.scm.SCM;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import hudson.plugins.git.GitSCM;
-import hudson.plugins.git.UserRemoteConfig;
-import hudson.scm.SCM;
 
 public class RepoSCM implements SCMWrapper {
     public static final String REPO_SCM_CLASS_NAME = "hudson.plugins.repo.RepoScm";

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/SCMFactory.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/SCMFactory.java
@@ -4,17 +4,16 @@ import static net.uaznia.lukanus.hudson.plugins.gitparameter.scms.MultiSCM.MULTI
 import static net.uaznia.lukanus.hudson.plugins.gitparameter.scms.ProxySCM.PROXY_SCM_CLASS_NAME;
 import static net.uaznia.lukanus.hudson.plugins.gitparameter.scms.RepoSCM.REPO_SCM_CLASS_NAME;
 
+import com.google.common.base.Strings;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import hudson.scm.SCM;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
-import com.google.common.base.Strings;
-import hudson.plugins.git.GitSCM;
-import hudson.plugins.git.UserRemoteConfig;
-import hudson.scm.SCM;
 import net.uaznia.lukanus.hudson.plugins.gitparameter.jobs.JobWrapper;
 
 public class SCMFactory {
@@ -34,7 +33,10 @@ public class SCMFactory {
             try {
                 repositoryNamePattern = Pattern.compile(repositoryRegExpName);
             } catch (Exception e) {
-                LOGGER.log(Level.INFO, Messages.SCMFactory_invalidUseRepositoryPattern(repositoryRegExpName), e.getMessage());
+                LOGGER.log(
+                        Level.INFO,
+                        Messages.SCMFactory_invalidUseRepositoryPattern(repositoryRegExpName),
+                        e.getMessage());
                 return getFirstGitSCM(scms);
             }
             return matchAndGetGitSCM(scms, repositoryNamePattern);
@@ -105,5 +107,4 @@ public class SCMFactory {
         }
         return projectSCMs;
     }
-
 }

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/SCMWrapper.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/SCMWrapper.java
@@ -1,8 +1,7 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.scms;
 
-import java.util.List;
-
 import hudson.scm.SCM;
+import java.util.List;
 
 public interface SCMWrapper {
     List<SCM> getSCMs();

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/SingleSCM.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/scms/SingleSCM.java
@@ -1,9 +1,8 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter.scms;
 
+import hudson.scm.SCM;
 import java.util.Collections;
 import java.util.List;
-
-import hudson.scm.SCM;
 
 public class SingleSCM implements SCMWrapper {
     private SCM scm;

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/BasicTests.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/BasicTests.java
@@ -1,14 +1,5 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
-import hudson.model.ParameterValue;
-import net.sf.json.JSONObject;
-import org.junit.Test;
-import org.kohsuke.stapler.StaplerRequest;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-
 import static net.uaznia.lukanus.hudson.plugins.gitparameter.Constants.DEFAULT_VALUE;
 import static net.uaznia.lukanus.hudson.plugins.gitparameter.Constants.NAME;
 import static net.uaznia.lukanus.hudson.plugins.gitparameter.Constants.PT_REVISION;
@@ -16,6 +7,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import hudson.model.ParameterValue;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import net.sf.json.JSONObject;
+import org.junit.Test;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * This test don't use jenkis rule
@@ -26,7 +25,18 @@ public class BasicTests {
      */
     @Test
     public void testCreateValue_StaplerRequest() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", ".*", "*", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                ".*",
+                "*",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
 
         StaplerRequest request = mock(StaplerRequest.class);
         ParameterValue result = instance.createValue(request);
@@ -50,10 +60,21 @@ public class BasicTests {
 
     @Test
     public void testCreateValue_StaplerRequest_ValueInRequest() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", ".*", "*", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                ".*",
+                "*",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
 
         StaplerRequest request = mock(StaplerRequest.class);
-        when(request.getParameterValues(instance.getName())).thenReturn(new String[]{"master"});
+        when(request.getParameterValues(instance.getName())).thenReturn(new String[] {"master"});
         ParameterValue result = instance.createValue(request);
 
         assertEquals(result, new GitParameterValue(NAME, "master"));
@@ -61,28 +82,72 @@ public class BasicTests {
 
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenNull() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", null, null, SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                null,
+                null,
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
         assertEquals("*", instance.getTagFilter());
         assertEquals(".*", instance.getBranchFilter());
     }
 
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenWhitespace() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", "  ", "  ", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                "  ",
+                "  ",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
         assertEquals("*", instance.getTagFilter());
         assertEquals(".*", instance.getBranchFilter());
     }
 
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenEmpty() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", "", "", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                "",
+                "",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
         assertEquals("*", instance.getTagFilter());
         assertEquals(".*", instance.getBranchFilter());
     }
 
     @Test
     public void testConstructorInitializesTagToGivenValueWhenNotNullOrWhitespace() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", "foobar", "foobar", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                "foobar",
+                "foobar",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
         assertEquals("foobar", instance.getTagFilter());
         assertEquals("foobar", instance.getBranchFilter());
     }
@@ -101,8 +166,18 @@ public class BasicTests {
 
         JSONObject jO = JSONObject.fromObject(jsonR);
 
-
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", ".*", "*", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                ".*",
+                "*",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
 
         ParameterValue result = instance.createValue(request, jO);
 
@@ -116,7 +191,7 @@ public class BasicTests {
     public void testGetDefaultParameterValue() {
 
         // TODO review the generated test code and remove the default call to fail.
-        //fail("The test case is a prototype.");
+        // fail("The test case is a prototype.");
     }
 
     /**
@@ -125,7 +200,18 @@ public class BasicTests {
     @Test
     public void testGetParameterType() {
         String expResult = PT_REVISION;
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, expResult, DEFAULT_VALUE, "description", "branch", ".*", "*", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                expResult,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                ".*",
+                "*",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
         String result = instance.getParameterType();
         assertEquals(expResult, result);
 
@@ -140,7 +226,18 @@ public class BasicTests {
     @Test
     public void testSetParameterType() {
         String expResult = PT_REVISION;
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, "asdf", DEFAULT_VALUE, "description", "branch", ".*", "*", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                "asdf",
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                ".*",
+                "*",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
 
         instance.setParameterType(expResult);
         String result = instance.getParameterType();
@@ -149,7 +246,18 @@ public class BasicTests {
 
     @Test
     public void testWrongType() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, "asdf", DEFAULT_VALUE, "description", "branch", ".*", "*", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                "asdf",
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                ".*",
+                "*",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
 
         String result = instance.getParameterType();
         assertEquals("PT_BRANCH", result);
@@ -163,7 +271,18 @@ public class BasicTests {
         System.out.println("getDefaultValue");
         String expResult = DEFAULT_VALUE;
 
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, "asdf", expResult, "description", "branch", ".*", "*", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                "asdf",
+                expResult,
+                "description",
+                "branch",
+                ".*",
+                "*",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
         String result = instance.getDefaultValue();
         assertEquals(expResult, result);
     }
@@ -176,7 +295,18 @@ public class BasicTests {
         System.out.println("getDefaultValue");
         String expResult = DEFAULT_VALUE;
 
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, "asdf", "other", "description", "branch", ".*", "*", SortMode.NONE, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                "asdf",
+                "other",
+                "description",
+                "branch",
+                ".*",
+                "*",
+                SortMode.NONE,
+                SelectedValue.NONE,
+                null,
+                false);
         instance.setDefaultValue(expResult);
 
         String result = instance.getDefaultValue();
@@ -187,6 +317,5 @@ public class BasicTests {
      * Test of generateContents method, of class GitParameterDefinition.
      */
     @Test
-    public void testGenerateContents() {
-    }
+    public void testGenerateContents() {}
 }

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/RevisionInfoFactoryTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/RevisionInfoFactoryTest.java
@@ -1,75 +1,83 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import hudson.plugins.git.GitException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public class RevisionInfoFactoryTest {
     private static final String COMMIT_HASH_1 = "ee650d9b5dbc39ec1bdfc6608f49db94ce8d7be4";
     private static final ObjectId SHA1_1 = ObjectId.fromString(COMMIT_HASH_1);
-    private static final String[] RAW_1 = {"tree ee650d9b5dbc39ec1bdfc6608f49db94ce8d7be4",
-            "parent 3409e0e7a3c0a2887b14c95d803b90f9314606aa",
-            "author klimas7 <klimas7@gmail.com> 1523905899 +0200",
-            "committer klimas7 <klimas7@gmail.com> 1523905899 +0200",
-            "",
-            "    Version 0.9.2",
-            "",
-            ":100644 100644 ab9cfc8ef1c067ef36fb45741be8b9444ba7085c a01738c8f727254fdcf9d03fcb0965567104a31e M\tREADME.textile"};
-
+    private static final String[] RAW_1 = {
+        "tree ee650d9b5dbc39ec1bdfc6608f49db94ce8d7be4",
+        "parent 3409e0e7a3c0a2887b14c95d803b90f9314606aa",
+        "author klimas7 <klimas7@gmail.com> 1523905899 +0200",
+        "committer klimas7 <klimas7@gmail.com> 1523905899 +0200",
+        "",
+        "    Version 0.9.2",
+        "",
+        ":100644 100644 ab9cfc8ef1c067ef36fb45741be8b9444ba7085c a01738c8f727254fdcf9d03fcb0965567104a31e M\tREADME.textile"
+    };
 
     private static final String COMMIT_HASH_2 = "b9a246e842a5478fe01b52eb93e0e23cdb79f616";
     private static final ObjectId SHA1_2 = ObjectId.fromString(COMMIT_HASH_2);
-    private static final String[] RAW_2 = {"tree b9a246e842a5478fe01b52eb93e0e23cdb79f616",
-            "parent 3409e0e7a3c0a2887b14c95d803b90f9314606aa",
-            "author klimas7 <klimas7@gmail.com> 2018-05-23T15:28:13+0200",
-            "committer klimas7 <klimas7@gmail.com> 2018-05-23T15:28:13+0200"};
+    private static final String[] RAW_2 = {
+        "tree b9a246e842a5478fe01b52eb93e0e23cdb79f616",
+        "parent 3409e0e7a3c0a2887b14c95d803b90f9314606aa",
+        "author klimas7 <klimas7@gmail.com> 2018-05-23T15:28:13+0200",
+        "committer klimas7 <klimas7@gmail.com> 2018-05-23T15:28:13+0200"
+    };
 
     private static final String COMMIT_HASH_3 = "b9a246e842a5478fe01b52eb93e0e23cdb79f616";
     private static final ObjectId SHA1_3 = ObjectId.fromString(COMMIT_HASH_3);
-    private static final String[] RAW_NO_AUTHOR = {"tree b9a246e842a5478fe01b52eb93e0e23cdb79f616",
-            "parent 3409e0e7a3c0a2887b14c95d803b90f9314606aa",
-            "committer klimas7 <klimas7@gmail.com> 2018-05-23T15:28:13+0200"};
+    private static final String[] RAW_NO_AUTHOR = {
+        "tree b9a246e842a5478fe01b52eb93e0e23cdb79f616",
+        "parent 3409e0e7a3c0a2887b14c95d803b90f9314606aa",
+        "committer klimas7 <klimas7@gmail.com> 2018-05-23T15:28:13+0200"
+    };
     private static final String SHORT_COMMIT_HASH_3 = COMMIT_HASH_3.substring(0, 8);
 
     private static final String COMMIT_HASH_4 = "f36014bb502c66259cace1ac6a42317cb120d926";
     private static final ObjectId SHA1_4 = ObjectId.fromString(COMMIT_HASH_4);
-    private static final String[] RAW_4 = {"commit d13e0b12d645e68d15f52cdf32ec98c9731fe3b8",
-            "tree f36014bb502c66259cace1ac6a42317cb120d926",
-            "parent 54a7ea2118c56af484075016e3867512b65a75b6",
-            "author Nick Whelan <nickw@indeed.com> 1423782469 -0600",
-            "committer Joe Hansche <jhansche@meetme.com> 1427401175 -0400",
-            "",
-            "    Performance improvements",
-            "    ",
-            "    Performance improvements when listing tags and branches. It's not necessary",
-            "    to perform a fetch operation when listing remote tags and branches, if",
-            "    using ls-remote.",
-            "",
-            ":100644 100644 12504dff00708931ca5bd94faa8d4d91fd964e26 6faa30e2cff5d93c1425d85308acb0b7cad21539 M\tsrc/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java",
-            ":100644 100644 792aab5dfe8f6925d56012e97a87802dab926f60 be1db20696d5ffea041c86e6cea13828b95e19bf M\tsrc/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly",
-            ":100644 000000 54b37e567a56583bc61fef860bcd45b946e2053c 0000000000000000000000000000000000000000 D\tsrc/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-branchfilter.html",
-            ":000000 100644 0000000000000000000000000000000000000000 71b8e86fa081074b4df8f2ba4fa3321b763be722 A\tsrc/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-filter.html",
-            ":100644 100644 c5bc2243cd449f88c31262208b142a98620f9f90 4580a726212cd65f5438a79350ad1fa002bbdd11 M\tsrc/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java"};
+    private static final String[] RAW_4 = {
+        "commit d13e0b12d645e68d15f52cdf32ec98c9731fe3b8",
+        "tree f36014bb502c66259cace1ac6a42317cb120d926",
+        "parent 54a7ea2118c56af484075016e3867512b65a75b6",
+        "author Nick Whelan <nickw@indeed.com> 1423782469 -0600",
+        "committer Joe Hansche <jhansche@meetme.com> 1427401175 -0400",
+        "",
+        "    Performance improvements",
+        "    ",
+        "    Performance improvements when listing tags and branches. It's not necessary",
+        "    to perform a fetch operation when listing remote tags and branches, if",
+        "    using ls-remote.",
+        "",
+        ":100644 100644 12504dff00708931ca5bd94faa8d4d91fd964e26 6faa30e2cff5d93c1425d85308acb0b7cad21539 M\tsrc/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java",
+        ":100644 100644 792aab5dfe8f6925d56012e97a87802dab926f60 be1db20696d5ffea041c86e6cea13828b95e19bf M\tsrc/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly",
+        ":100644 000000 54b37e567a56583bc61fef860bcd45b946e2053c 0000000000000000000000000000000000000000 D\tsrc/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-branchfilter.html",
+        ":000000 100644 0000000000000000000000000000000000000000 71b8e86fa081074b4df8f2ba4fa3321b763be722 A\tsrc/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-filter.html",
+        ":100644 100644 c5bc2243cd449f88c31262208b142a98620f9f90 4580a726212cd65f5438a79350ad1fa002bbdd11 M\tsrc/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java"
+    };
 
     private static final String COMMIT_HASH_5 = "c0c83cf111f8b2da0c7f8b63a98e812e95769f20";
     private static final ObjectId SHA1_5 = ObjectId.fromString(COMMIT_HASH_5);
-    private static final String[] RAW_5 = {"tree c0c83cf111f8b2da0c7f8b63a98e812e95769f20",
-            "parent 3409e0e7a3c0a2887b14c95d803b90f9314606aa",
-            "author klimas7 <klimas7@gmail.com> 1523905899 +0200",
-            "committer klimas7 <klimas7@gmail.com> 1523905899 +0200",
-            "",
-            "    Very_long_commit_message_with_no_space_Lorem_ipsum_dolor_sit_amet__consectetur_adipiscing_elit__sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua",
-            "",
-            ":100644 100644 ab9cfc8ef1c067ef36fb45741be8b9444ba7085c a01738c8f727254fdcf9d03fcb0965567104a31e M\tREADME.textile"};
+    private static final String[] RAW_5 = {
+        "tree c0c83cf111f8b2da0c7f8b63a98e812e95769f20",
+        "parent 3409e0e7a3c0a2887b14c95d803b90f9314606aa",
+        "author klimas7 <klimas7@gmail.com> 1523905899 +0200",
+        "committer klimas7 <klimas7@gmail.com> 1523905899 +0200",
+        "",
+        "    Very_long_commit_message_with_no_space_Lorem_ipsum_dolor_sit_amet__consectetur_adipiscing_elit__sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua",
+        "",
+        ":100644 100644 ab9cfc8ef1c067ef36fb45741be8b9444ba7085c a01738c8f727254fdcf9d03fcb0965567104a31e M\tREADME.textile"
+    };
 
     @Test
     public void testGetRevisions() throws InterruptedException {
@@ -84,10 +92,18 @@ public class RevisionInfoFactoryTest {
         List<RevisionInfo> revisions = revisionInfoFactory.getRevisions();
 
         assertEquals(4, revisions.size());
-        assertEquals("ee650d9b 2018-04-16 21:11 klimas7 <klimas7@gmail.com> Version 0.9.2", revisions.get(0).getRevisionInfo());
-        assertEquals("b9a246e8 2018-05-23T15:28:13+0200 klimas7 <klimas7@gmail.com>", revisions.get(1).getRevisionInfo());
-        assertEquals("f36014bb 2015-02-12 17:07 Nick Whelan <nickw@indeed.com> Performance improvements Performance improvements when listing tags and branches. It's not necessary to perform a fetch operation when listing remote ...", revisions.get(2).getRevisionInfo());
-        assertEquals("c0c83cf1 2018-04-16 21:11 klimas7 <klimas7@gmail.com> Very_long_commit_message_with_no_space_Lorem_ipsum_dolor_sit_amet__consectetur_adipiscing_elit__sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_m ...", revisions.get(3).getRevisionInfo());
+        assertEquals(
+                "ee650d9b 2018-04-16 21:11 klimas7 <klimas7@gmail.com> Version 0.9.2",
+                revisions.get(0).getRevisionInfo());
+        assertEquals(
+                "b9a246e8 2018-05-23T15:28:13+0200 klimas7 <klimas7@gmail.com>",
+                revisions.get(1).getRevisionInfo());
+        assertEquals(
+                "f36014bb 2015-02-12 17:07 Nick Whelan <nickw@indeed.com> Performance improvements Performance improvements when listing tags and branches. It's not necessary to perform a fetch operation when listing remote ...",
+                revisions.get(2).getRevisionInfo());
+        assertEquals(
+                "c0c83cf1 2018-04-16 21:11 klimas7 <klimas7@gmail.com> Very_long_commit_message_with_no_space_Lorem_ipsum_dolor_sit_amet__consectetur_adipiscing_elit__sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_m ...",
+                revisions.get(3).getRevisionInfo());
     }
 
     @Test

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SmartNumberStringComparerTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SmartNumberStringComparerTest.java
@@ -1,10 +1,9 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Comparator;
-
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class SmartNumberStringComparerTest {
 
@@ -32,5 +31,4 @@ public class SmartNumberStringComparerTest {
         assertTrue(comparer.compare("v_1.1.1.1", "v_1.1.2") < 0);
         assertTrue(comparer.compare("v_1", "v_2.0.0.0") < 0);
     }
-
 }

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SortTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/SortTest.java
@@ -1,11 +1,5 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
-
 import static net.uaznia.lukanus.hudson.plugins.gitparameter.Constants.DEFAULT_VALUE;
 import static net.uaznia.lukanus.hudson.plugins.gitparameter.Constants.NAME;
 import static net.uaznia.lukanus.hudson.plugins.gitparameter.Constants.PT_REVISION;
@@ -13,10 +7,26 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
 public class SortTest {
     @Test
     public void testSortTagsYieldsCorrectOrderWithSmartSortEnabled() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", null, null, SortMode.ASCENDING_SMART, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                null,
+                null,
+                SortMode.ASCENDING_SMART,
+                SelectedValue.NONE,
+                null,
+                false);
         Set<String> tags = new HashSet<>();
         tags.add("v_1.0.0.2");
         tags.add("v_1.0.0.5");
@@ -35,7 +45,18 @@ public class SortTest {
 
     @Test
     public void testSortTagsYieldsCorrectOrderWithSmartSortDisabled() {
-        GitParameterDefinition instance = new GitParameterDefinition(NAME, PT_REVISION, DEFAULT_VALUE, "description", "branch", null, null, SortMode.ASCENDING, SelectedValue.NONE, null, false);
+        GitParameterDefinition instance = new GitParameterDefinition(
+                NAME,
+                PT_REVISION,
+                DEFAULT_VALUE,
+                "description",
+                "branch",
+                null,
+                null,
+                SortMode.ASCENDING,
+                SelectedValue.NONE,
+                null,
+                false);
         Set<String> tags = new HashSet<>();
         tags.add("v_1.0.0.2");
         tags.add("v_1.0.0.5");

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/UiAcceptanceTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/UiAcceptanceTest.java
@@ -1,6 +1,9 @@
 package net.uaznia.lukanus.hudson.plugins.gitparameter;
 
+import static org.junit.Assert.assertTrue;
+
 import io.github.bonigarcia.wdm.WebDriverManager;
+import java.time.Duration;
 import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -17,10 +20,6 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.time.Duration;
-
-import static org.junit.Assert.assertTrue;
-
 public class UiAcceptanceTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -33,7 +32,8 @@ public class UiAcceptanceTest {
             // The browserVersion needs to match what is provided by the Jenkins Infrastructure
             // If you see an exception like this:
             //
-            // org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: session not created: This version of ChromeDriver only supports Chrome version 114
+            // org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500.
+            // Message: session not created: This version of ChromeDriver only supports Chrome version 114
             // Current browser version is 112.0.5615.49 with binary path /usr/bin/chromium-browser
             //
             // Then that means you need to update the version here to match the current browser version.
@@ -50,7 +50,8 @@ public class UiAcceptanceTest {
     @Before
     public void setUp() throws Exception {
         if (isCi()) {
-            driver = new ChromeDriver(new ChromeOptions().addArguments("--headless", "--disable-dev-shm-usage", "--no-sandbox"));
+            driver = new ChromeDriver(
+                    new ChromeOptions().addArguments("--headless", "--disable-dev-shm-usage", "--no-sandbox"));
         } else {
             driver = new ChromeDriver(new ChromeOptions());
         }
@@ -71,16 +72,20 @@ public class UiAcceptanceTest {
         WebElement revisionParam = driver.findElement(byParamName("Revision"));
 
         new WebDriverWait(driver, Duration.ofSeconds(60))
-                .until(driver1 -> new Select(driver1.findElement(byParamName("Revision"))).getOptions().size() > 1);
+                .until(driver1 -> new Select(driver1.findElement(byParamName("Revision")))
+                                .getOptions()
+                                .size()
+                        > 1);
 
-        assertTrue(new Select(branchParam).getOptions().stream().anyMatch(option -> option.getAttribute("value").equals("origin/master")));
-        assertTrue(new Select(tagParam).getOptions().stream().anyMatch(option -> option.getAttribute("value").equals("git-parameter-0.9.7")));
-        assertTrue(new Select(revisionParam).getOptions().stream().anyMatch(option -> option.getAttribute("value").equals("00a8385cba1e4e32cf823775e2b3dbe5eb27931d")));
-
+        assertTrue(new Select(branchParam).getOptions().stream().anyMatch(option -> option.getAttribute("value")
+                .equals("origin/master")));
+        assertTrue(new Select(tagParam).getOptions().stream().anyMatch(option -> option.getAttribute("value")
+                .equals("git-parameter-0.9.7")));
+        assertTrue(new Select(revisionParam).getOptions().stream().anyMatch(option -> option.getAttribute("value")
+                .equals("00a8385cba1e4e32cf823775e2b3dbe5eb27931d")));
     }
 
     private static By byParamName(String paramName) {
         return By.cssSelector("div[name='parameter']:has([name='name'][value='" + paramName + "']) > select");
     }
-
 }


### PR DESCRIPTION
Applies the Jenkins project-wide autoformatting settings to this repository. If accepted, I will also add a `.git-blame-ignore-revs` file to make it easier to browse the history.