### PR TITLE
JENKINS-73658 Support regex for tag filter

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagFilter.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagFilter.html
@@ -1,6 +1,7 @@
 <div>
     This parameter is used to get tag from git.<br/>
     If is blank, parameter is set to "*".<br/>
+    Regex patterns must be prefixed with with a forward slash (ie /.*).
     Properly is executed command: <tt>git ls-remote -t &lt;repository&gt; "*"</tt> or <tt>git ls-remote -t &lt;repository&gt; "$tagFilter"</tt>.<br/>
     <a href="https://git-scm.com/docs/git-ls-remote.html">git-ls-remote</a> documentation.
 </div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagFilter.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagFilter.html
@@ -1,7 +1,7 @@
 <div>
     This parameter is used to get tag from git.<br/>
     If is blank, parameter is set to "*".<br/>
-    Regex patterns must be prefixed with with a forward slash (ie /.*).
+    Regex patterns must be prefixed with with a forward slash (ie /.*).<br/>
     Properly is executed command: <tt>git ls-remote -t &lt;repository&gt; "*"</tt> or <tt>git ls-remote -t &lt;repository&gt; "$tagFilter"</tt>.<br/>
     <a href="https://git-scm.com/docs/git-ls-remote.html">git-ls-remote</a> documentation.
 </div>


### PR DESCRIPTION
This PR adds logic to allow for a regex filter to be used for the tagFilter. The changes include:
* Add this new option to the parameter description displayed in Jenkins.
* If the tagFilter supplied starts with a forward slash ('/') it is assumed to be a regex pattern. As a result, the git client call for tags will use an asterisk instead of the tagFilter (pulling all tag names).
* If we're using a regex pattern, only tags that match will be included.

### Testing done

In a local instance of Jenkins, installed the plugin and ensured the following patterns functioned as desired:
* No filter ('').
* A plain text filter ('dev').
* A wildcard text filter ('staging*').
* A regex pattern filter ('/.*(dev|staging).*').

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira: https://issues.jenkins.io/browse/JENKINS-73658
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<img width="664" alt="image" src="https://github.com/user-attachments/assets/f83ca12a-0e6f-4826-8189-bdcbb311a667">
<img width="223" alt="image" src="https://github.com/user-attachments/assets/b17538c6-2a1b-4f96-99a2-7011f4ef6f95">
