### PR TITLE
Require Jenkins 2.452.4 or newer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
----
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
@@ -13,7 +14,6 @@
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>Git Parameter Plug-In</name>
-  <description>Adds ability to choose branches, tags  or revisions from git repositories configured in project.</description>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,8 @@
     <revision>0.9.20</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.baseline>2.452</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -60,8 +61,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3559.vb_5b_81183b_d23</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   </scm>
 
   <properties>
-    <revision>0.9.20</revision>
+    <revision>0.10.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
     <jenkins.baseline>2.452</jenkins.baseline>

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import net.sf.json.JSONObject;
 import net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition.DescriptorImpl;
 import net.uaznia.lukanus.hudson.plugins.gitparameter.jobs.JobWrapper;
@@ -701,7 +700,7 @@ public class GitParameterDefinitionTest {
     }
 
     @Test
-    public void testWorkflowJobWithCpsFlowDefinition() throws IOException, InterruptedException, ExecutionException {
+    public void testWorkflowJobWithCpsFlowDefinition() throws Exception {
         WorkflowJob p = jenkins.createProject(WorkflowJob.class, "wfj");
         String script =
                 "node {\n" + " git url: '" + GIT_PARAMETER_REPOSITORY_URL + "' \n" + " echo 'Some message'\n" + "}";


### PR DESCRIPTION
## Require Jenkins 2.452.4 or newer

Jenkins 2.452.4 includes a critical security fix that make it a good minimum Jenkins version.  It is also one of the versions recommended:

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

As of June 2024, 60% of installations of the most recent release were using Jenkins 2.440 or newer.  With advisories and typical uprade patterns, the percentage is certainly even higher now.

Additional changes:

* Use standard dependabot configuration and format
* Use 0.10.0 as next release
* Remove description attribute from pom, replaced by src/main/resources/index.jelly

### Testing done

Automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
