### PR TITLE
Remove character set dependency from assertion

### DIFF
--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
@@ -390,13 +390,7 @@ class GitParameterDefinitionTest {
         assertNotNull(build);
         ItemsErrorModel items = def.getDescriptor().doFillValueItems(project, def.getName());
         assertTrue(isListBoxItem(items, "00a8385cba1e4e32cf823775e2b3dbe5eb27931d"));
-        if (!Functions.isWindows() || System.getenv("CI") == null) {
-            // Windows agents on AWS ci.jenkins.io changed character set configuration compared to Azure
-            // Only test when not on Windows and not on a CI configuration
-            // TODO: Remove conditional when AWS ci.jenkins.io agent character set config is updated
-            assertTrue(isListBoxItemName(
-                    items, "00a8385c 2011-10-30 17:11 Łukasz Miłkowski <lukanus@uaznia.net> initial readme"));
-        }
+        assertTrue(isListBoxItemName(items, "00a8385c 2011-10-30 17:11 "));
     }
 
     @Test


### PR DESCRIPTION
## Remove character set dependency from assertion

The assertion is intended to confirm that the correct item is in the list, not that the current environment is using a specific character set.  Removes the non-ASCII character from the assertion while retaining the SHA-1 segment and the date string.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.  Rely on ci.jenkins.io to confirm Windows with Java 11.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
