### PR TITLE
[JENKINS-75462] Fix filter drop select input is out of style with other components

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -8,48 +8,50 @@
         <f:textarea name="description" value="${description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
     <f:entry title="${%parameter.type}" field="type">
-        <select name="type">
-            <j:choose>
-                <j:when test="${instance.parameterType eq 'PT_TAG'}">
-                    <option value="PT_TAG" selected="selected">${%parameter.tag}</option>
-                </j:when>
-                <j:otherwise>
-                    <option value="PT_TAG">${%parameter.tag}</option>
-                </j:otherwise>
-            </j:choose>
-            <j:choose>
-                <j:when test="${instance.parameterType eq 'PT_BRANCH'}">
-                    <option value="PT_BRANCH" selected="selected">${%parameter.branch}</option>
-                </j:when>
-                <j:otherwise>
-                    <option value="PT_BRANCH">${%parameter.branch}</option>
-                </j:otherwise>
-            </j:choose>
-            <j:choose>
-                <j:when test="${instance.parameterType eq 'PT_BRANCH_TAG'}">
-                    <option value="PT_BRANCH_TAG" selected="selected">${%parameter.branch.or.tag}</option>
-                </j:when>
-                <j:otherwise>
-                    <option value="PT_BRANCH_TAG">${%parameter.branch.or.tag}</option>
-                </j:otherwise>
-            </j:choose>
-            <j:choose>
-                <j:when test="${instance.parameterType eq 'PT_REVISION'}">
-                    <option value="PT_REVISION" selected="selected">${%parameter.revision}</option>
-                </j:when>
-                <j:otherwise>
-                    <option value="PT_REVISION">${%parameter.revision}</option>
-                </j:otherwise>
-            </j:choose>
-            <j:choose>
-                <j:when test="${instance.parameterType eq 'PT_PULL_REQUEST'}">
-                    <option value="PT_PULL_REQUEST" selected="selected">${%parameter.pull.request}</option>
-                </j:when>
-                <j:otherwise>
-                    <option value="PT_PULL_REQUEST">${%parameter.pull.request}</option>
-                </j:otherwise>
-            </j:choose>
-        </select>
+        <div class="jenkins-select">
+            <select class="jenkins-select__input" name="type">
+                <j:choose>
+                    <j:when test="${instance.parameterType eq 'PT_TAG'}">
+                        <option value="PT_TAG" selected="selected">${%parameter.tag}</option>
+                    </j:when>
+                    <j:otherwise>
+                        <option value="PT_TAG">${%parameter.tag}</option>
+                    </j:otherwise>
+                </j:choose>
+                <j:choose>
+                    <j:when test="${instance.parameterType eq 'PT_BRANCH'}">
+                        <option value="PT_BRANCH" selected="selected">${%parameter.branch}</option>
+                    </j:when>
+                    <j:otherwise>
+                        <option value="PT_BRANCH">${%parameter.branch}</option>
+                    </j:otherwise>
+                </j:choose>
+                <j:choose>
+                    <j:when test="${instance.parameterType eq 'PT_BRANCH_TAG'}">
+                        <option value="PT_BRANCH_TAG" selected="selected">${%parameter.branch.or.tag}</option>
+                    </j:when>
+                    <j:otherwise>
+                        <option value="PT_BRANCH_TAG">${%parameter.branch.or.tag}</option>
+                    </j:otherwise>
+                </j:choose>
+                <j:choose>
+                    <j:when test="${instance.parameterType eq 'PT_REVISION'}">
+                        <option value="PT_REVISION" selected="selected">${%parameter.revision}</option>
+                    </j:when>
+                    <j:otherwise>
+                        <option value="PT_REVISION">${%parameter.revision}</option>
+                    </j:otherwise>
+                </j:choose>
+                <j:choose>
+                    <j:when test="${instance.parameterType eq 'PT_PULL_REQUEST'}">
+                        <option value="PT_PULL_REQUEST" selected="selected">${%parameter.pull.request}</option>
+                    </j:when>
+                    <j:otherwise>
+                        <option value="PT_PULL_REQUEST">${%parameter.pull.request}</option>
+                    </j:otherwise>
+                </j:choose>
+            </select>
+        </div>
     </f:entry>
     <f:entry title="${%parameter.default.value}" field="defaultValue">
         <f:textbox/>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
See [JENKINS-75462](https://issues.jenkins.io/browse/JENKINS-75462).
### Testing done
#### Before:
![CleanShot 2025-03-21 at 14 50 39](https://github.com/user-attachments/assets/3849ff4a-bb01-4a2b-8d66-6854b199ffaf)

#### After:
![CleanShot 2025-03-21 at 14 48 24](https://github.com/user-attachments/assets/ac424997-b748-4aa1-a3c6-24b6c8391975)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
