### PR TITLE
[JENKINS-76185] Add GitLab merge request compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ pipeline {
   parameters {
     gitParameter type: 'PT_PULL_REQUEST',
                  name: 'A_PULL_REQUEST',
-                 defaultValue: '',
+                 defaultValue: '1818',
                  description: 'Choose a pull request to checkout',
                  selectedValue: 'TOP',
                  sortMode: 'DESCENDING_SMART'
@@ -145,8 +145,9 @@ pipeline {
   stages {
     stage('Example') {
       steps {
+        echo "Parameter is ${params.A_PULL_REQUEST}"
         checkout scmGit(branches: [[name: "pr/${params.A_PULL_REQUEST}/head"]],
-                        userRemoteConfigs: [[refspec: '+refs/pull/*:refs/remotes/origin/pr/*',
+                        userRemoteConfigs: [[refspec: "+refs/pull/${params.A_PULL_REQUEST}/head:refs/pull/${params.A_PULL_REQUEST}/head",
                                              url: 'https://github.com/jenkinsci/git-plugin.git']])
       }
     }

--- a/README.md
+++ b/README.md
@@ -129,7 +129,14 @@ pipeline {
 
 ### `PT_PULL_REQUEST` type
 
-The `PT_PULL_REQUEST` type lists pull requests in the remote repository.
+The `PT_PULL_REQUEST` type lists pull requests or merge requests in the remote repository.
+
+Supports:
+- GitHub Pull Requests
+- Bitbucket Pull Requests
+- GitLab Merge Requests
+
+#### GitHub Example
 
 ```groovy
 pipeline {
@@ -148,6 +155,31 @@ pipeline {
         checkout scmGit(branches: [[name: "pr/${params.A_PULL_REQUEST}/head"]],
                         userRemoteConfigs: [[refspec: "+refs/pull/${params.A_PULL_REQUEST}/head:refs/pull/${params.A_PULL_REQUEST}/head",
                                              url: 'https://github.com/jenkinsci/git-plugin.git']])
+      }
+    }
+  }
+}
+```
+
+#### GitLab Example
+
+```groovy
+pipeline {
+  agent any
+  parameters {
+    gitParameter type: 'PT_PULL_REQUEST',
+                 name: 'MERGE_REQUEST',
+                 defaultValue: '',
+                 description: 'Choose a merge request to checkout',
+                 selectedValue: 'TOP',
+                 sortMode: 'DESCENDING_SMART'
+  }
+  stages {
+    stage('Example') {
+      steps {
+        checkout scmGit(branches: [[name: "refs/remotes/origin/merge-requests/${params.MERGE_REQUEST}/head"]],
+                        userRemoteConfigs: [[refspec: '+refs/merge-requests/*:refs/remotes/origin/merge-requests/*',
+                                             url: 'https://gitlab.com/your-group/your-project.git']])
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ pipeline {
   stages {
     stage('Example') {
       steps {
-        echo "Parameter is ${params.A_PULL_REQUEST}"
         checkout scmGit(branches: [[name: "pr/${params.A_PULL_REQUEST}/head"]],
                         userRemoteConfigs: [[refspec: "+refs/pull/${params.A_PULL_REQUEST}/head:refs/pull/${params.A_PULL_REQUEST}/head",
                                              url: 'https://github.com/jenkinsci/git-plugin.git']])

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/Consts.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/Consts.java
@@ -13,7 +13,8 @@ public class Consts {
     public static final String PARAMETER_TYPE_TAG_BRANCH = "PT_BRANCH_TAG";
     public static final String PARAMETER_TYPE_PULL_REQUEST = "PT_PULL_REQUEST";
 
-    public static final Pattern PULL_REQUEST_REFS_PATTERN = Pattern.compile("refs/(pull.*|merge-requests)/(\\d+)/(from|head)");
+    public static final Pattern PULL_REQUEST_REFS_PATTERN =
+            Pattern.compile("refs/(pull.*|merge-requests)/(\\d+)/(from|head)");
 
     public static final String TEMPORARY_DIRECTORY_PREFIX = "git_parameter_";
     public static final String EMPTY_JOB_NAME = "EMPTY_JOB_NAME";

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/Consts.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/Consts.java
@@ -13,7 +13,7 @@ public class Consts {
     public static final String PARAMETER_TYPE_TAG_BRANCH = "PT_BRANCH_TAG";
     public static final String PARAMETER_TYPE_PULL_REQUEST = "PT_PULL_REQUEST";
 
-    public static final Pattern PULL_REQUEST_REFS_PATTERN = Pattern.compile("refs/pull.*/(\\d+)/[from|head]");
+    public static final Pattern PULL_REQUEST_REFS_PATTERN = Pattern.compile("refs/(pull.*|merge-requests)/(\\d+)/(from|head)");
 
     public static final String TEMPORARY_DIRECTORY_PREFIX = "git_parameter_";
     public static final String EMPTY_JOB_NAME = "EMPTY_JOB_NAME";

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -457,7 +457,7 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
         for (String remoteReference : remoteReferences.keySet()) {
             Matcher matcher = PULL_REQUEST_REFS_PATTERN.matcher(remoteReference);
             if (matcher.find()) {
-                pullRequestSet.add(matcher.group(1));
+                pullRequestSet.add(matcher.group(2));
             }
         }
         return pullRequestSet;

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/BasicSafeTests.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/BasicSafeTests.java
@@ -51,14 +51,21 @@ class BasicSafeTests {
     void matchesWithBitbucketPullRequestRefs() {
         Matcher matcher = Consts.PULL_REQUEST_REFS_PATTERN.matcher("refs/pull-requests/186/from");
         assertTrue(matcher.find());
-        assertEquals("186", matcher.group(1));
+        assertEquals("186", matcher.group(2));
     }
 
     @Test
     void matchesWithGithubPullRequestRefs() {
         Matcher matcher = Consts.PULL_REQUEST_REFS_PATTERN.matcher("refs/pull/45/head");
         assertTrue(matcher.find());
-        assertEquals("45", matcher.group(1));
+        assertEquals("45", matcher.group(2));
+    }
+
+    @Test
+    void matchesWithGitLabMergeRequestRefs() {
+        Matcher matcher = Consts.PULL_REQUEST_REFS_PATTERN.matcher("refs/merge-requests/42/head");
+        assertTrue(matcher.find());
+        assertEquals("42", matcher.group(2));
     }
 
     @Test

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/BasicTests.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/BasicTests.java
@@ -61,14 +61,21 @@ class BasicTests {
     void matchesWithBitbucketPullRequestRefs() {
         Matcher matcher = Consts.PULL_REQUEST_REFS_PATTERN.matcher("refs/pull-requests/186/from");
         assertTrue(matcher.find());
-        assertEquals("186", matcher.group(1));
+        assertEquals("186", matcher.group(2));
     }
 
     @Test
     void matchesWithGithubPullRequestRefs() {
         Matcher matcher = Consts.PULL_REQUEST_REFS_PATTERN.matcher("refs/pull/45/head");
         assertTrue(matcher.find());
-        assertEquals("45", matcher.group(1));
+        assertEquals("45", matcher.group(2));
+    }
+
+    @Test
+    void matchesWithGitLabMergeRequestRefs() {
+        Matcher matcher = Consts.PULL_REQUEST_REFS_PATTERN.matcher("refs/merge-requests/42/head");
+        assertTrue(matcher.find());
+        assertEquals("42", matcher.group(2));
     }
 
     @Test


### PR DESCRIPTION
As mentions in [JENKINS-76185](https://issues.jenkins.io/browse/JENKINS-76185), I want to make it possible to use this plugin with Gitlab Merge Requests as well.

I would like to know if I missed something somewhere, as I am not yet familiar with this code base.

### Testing done

I tested it by running all the tests by `mvn test`.
Did not yet test it manually.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
