### PR TITLE
Improve phrasing of system configuration online help

### DIFF
--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-showNeedToCloneInformation.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-showNeedToCloneInformation.html
@@ -1,5 +1,10 @@
 <div>
-    The message should be displayed:<br/>
-    'If working space is empty, the plug needs clone the repository, before it can display the contents. This may take some time if you have a slow connection or repository is large.'<br/>
-    The message is displayed under the selection field. Only for revisions as a parameter type.
+  The message should be displayed:
+  <blockquote>
+    <p>
+      If the workspace is empty, the plugin needs to clone the repository before it can display the contents.
+      This may take some time if you have a slow connection or the repository is large.
+    </p>
+  </blockquote>
+  The message is displayed under the selection field for a <code>revision</code> parameter type.
 </div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.properties
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.properties
@@ -1,2 +1,2 @@
 retrieving.references=Retrieving Git references...
-needs.to.clone=If working space is empty, the plug needs clone the repository, before it can display the contents. This may take some time if you have a slow connection or repository is large.
+needs.to.clone=If the workspace is empty, the plugin needs to clone the repository before it can display the contents. This may take some time if you have a slow connection or the repository is large.


### PR DESCRIPTION
## Improve phrasing of system configuration online help

Workspace is the common term for the directory where Jenkins builds perform their work.

Use a blockquote because the help text includes the message that will be displayed.

### Testing done

Confirmed that the new help text displays correctly in Jenkins 2.528.1 from the "Manage Jenkins" page.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
