### PR TITLE
Do not write stack trace to system log for unauthorized API access

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -731,7 +731,15 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
             if (job == null) {
                 return ItemsErrorModel.EMPTY;
             }
-            job.checkPermission(Job.BUILD);
+            try {
+                job.checkPermission(Job.BUILD);
+            } catch (org.springframework.security.access.AccessDeniedException e) {
+                // Write the exception to the logger, not to the Jenkins log.
+                //
+                // https://github.com/jenkinsci/git-parameter-plugin/issues/339
+                LOGGER.log(Level.FINE, job.getDisplayName() + " " + e.getMessage(), e);
+                return ItemsErrorModel.EMPTY;
+            }
 
             JobWrapper jobWrapper = JobWrapperFactory.createJobWrapper(job);
 

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -737,7 +737,9 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
                 // Write the exception to the logger, not to the Jenkins log.
                 //
                 // https://github.com/jenkinsci/git-parameter-plugin/issues/339
-                LOGGER.log(Level.FINE, job.getDisplayName() + " " + e.getMessage(), e);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, job.getDisplayName() + " " + e.getMessage(), e);
+                }
                 return ItemsErrorModel.EMPTY;
             }
 


### PR DESCRIPTION
## Do not write stack trace to system log for unauthorized API access

Fixes #339

Return an empty list instead of throwing an exception. Write a message and the exception to the logger of the class when the logging level is FINE.

[SECURITY-3745](https://www.jenkins.io/security/advisory/2026-06-24/#SECURITY-3745) with the change in [496a59](https://github.com/jenkinsci/git-parameter-plugin/commit/496a59f698e5ada712dea1ebf980709f0040e394) adds a permission check that requires Item.BUILD permission in order to read the parameter values.  It relies on the checkPermission() method to throw an exception.  The exception is written to the Jenkins log.

The unguarded call to checkPermission() is a relatively common technique, but a user reported that it dramatically increases the size of their system logs.  Refer to issue:

* https://github.com/jenkinsci/git-parameter-plugin/issues/339

This pull request changes the behavior of the API when the request does not have permission.  The security fix caused the API to return:

>       "parameterDefinitions": []

The code in this commit returns:

>       "parameterDefinitions": [
>         {
>           "_class": "net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition",
>           "defaultParameterValue": {
>             "_class": "net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterValue",
>             "value": "jdk-17.0.19"
>           },
>           "description": "Choose tag to checkout",
>           "name": "PRIVATE_TAG",
>           "type": "GitParameterDefinition",
>           "allValueItems": {
>             "errors": [],
>             "values": []
>           }
>         }
>       ]

That means the default value for the parameter is now available to the read only user, when previously the default value was not available to the read only user.

I'd like an opinion from the @jenkinsci/jenkins-security-team before I merge this change, since the default value might be considered sensitive information.

### Testing done

* Confirmed that the stack trace is written to the Jenkins log by the latest release
* Confirmed that the stack trace is not written to the Jenkins log by this change
* Confirmed that the list of values is correctly not returned by this change
* Noted that the default value is visible with this change

I'd also like a report from the issue submitter @PetersNils that the incremental build has been installed and confirmed to work in the environment that had the issue.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
